### PR TITLE
feat: handle file as input when calling wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ open-attestation deploy token-registry "My Sample Token" MST --network ropsten -
 
 Example - with in-lined private key
 
-\*_Note that for this method, the private key may be stored in the machine's bash history_
+**Note that for this method, the private key may be stored in the machine's bash history*
 
 ```sh
 open-attestation deploy token-registry "My Sample Token" MST --network ropsten --key 0000000000000000000000000000000000000000000000000000000000000003

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This command process all documents in the input directory and issue all of them 
 batch. It will then add the issuance proofs to the individual documents.
 
 ```bash
-open-attestation wrap <PathToDocuments> <PathToWrappedDocuments>
+open-attestation wrap <PathToDocumentsOrFile> <PathToWrappedDocuments>
 ```
 
 Example:
@@ -31,6 +31,16 @@ Example:
 open-attestation wrap ./examples/raw-documents/ ./tmp/wrapped-documents/ --oav3
 
 ✔  success  Batch Document Root: 0xf51030c5751a646284c898cff0f9d833c64a50d6f307b61f2c96c3c838b13bfc
+```
+
+You can also set a single document as input
+
+Example:
+
+```bash
+open-attestation wrap ./examples/raw-documents/example.0.json ./tmp/wrapped-documents/ --schema ./examples/schema.json --oav3
+
+✔  success   Batch Document Root: 0x5d318c8083aac18f8075ca2a2eac74b06f2cc37d6ccad680c7c80c9bb36f7be1
 ```
 
 You can also provide an optional JSON schema document to perform extra check on the documents
@@ -127,7 +137,7 @@ open-attestation deploy token-registry "My Sample Token" MST --network ropsten -
 
 Example - with in-lined private key
 
-**Note that for this method, the private key may be stored in the machine's bash history*
+\*_Note that for this method, the private key may be stored in the machine's bash history_
 
 ```sh
 open-attestation deploy token-registry "My Sample Token" MST --network ropsten --key 0000000000000000000000000000000000000000000000000000000000000003

--- a/src/__tests__/wrap.e2e.test.ts
+++ b/src/__tests__/wrap.e2e.test.ts
@@ -13,7 +13,7 @@ const inputDirectory = path.resolve(__dirname, inputDirectoryName);
 const outputDirectory = path.resolve(__dirname, outputDirectoryName);
 
 describe("wrap", () => {
-  describe("wrap", () => {
+  describe("wrap with directory input", () => {
     // eslint-disable-next-line jest/no-hooks
     beforeEach(() => {
       fs.mkdirSync(inputDirectory);
@@ -244,6 +244,216 @@ describe("wrap", () => {
       it("should not issue documents when schema is not valid", async () => {
         await expect(
           wrap(inputDirectory, outputDirectory, {
+            schemaPath: path.resolve(__dirname, fixtureFolderName, "invalid-schema.json"),
+            version: "open-attestation/3.0",
+            unwrap: false
+          })
+        ).rejects.toThrow("Invalid schema, you must provide an $id property to your schema");
+        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+      });
+    });
+  });
+
+  describe("wrap with file input", () => {
+    // eslint-disable-next-line jest/no-hooks
+    beforeEach(() => {
+      fs.mkdirSync(inputDirectory);
+      fs.mkdirSync(outputDirectory);
+    });
+    // eslint-disable-next-line jest/no-hooks
+    afterEach(() => {
+      rimraf.sync(inputDirectory);
+      rimraf.sync(outputDirectory);
+    });
+    describe("without schema", () => {
+      it("should issue document when given valid open attestation document", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, validFileName),
+          path.resolve(__dirname, `${inputDirectoryName}/valid-open-attestation-document.json`)
+        );
+        const merkleRoot = await wrap(
+          path.resolve(__dirname, `${inputDirectoryName}/valid-open-attestation-document.json`),
+          outputDirectory,
+          {
+            version: "open-attestation/3.0",
+            unwrap: false
+          }
+        );
+
+        const file = JSON.parse(
+          fs.readFileSync(`${outputDirectory}/valid-open-attestation-document.json`, { encoding: "utf8" })
+        );
+        expect(merkleRoot).toHaveLength(64);
+        expect(merkleRoot).toStrictEqual(file.signature.merkleRoot);
+        expect(merkleRoot).toStrictEqual(file.signature.targetHash);
+      });
+      it("should not issue document when given invalid open attestation document", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, invalidFileName),
+          path.resolve(__dirname, `${inputDirectoryName}/invalid-open-attestation-document.json`)
+        );
+
+        await expect(
+          wrap(
+            path.resolve(__dirname, `${inputDirectoryName}/invalid-open-attestation-document.json`),
+            outputDirectory,
+            {
+              version: "open-attestation/3.0",
+              unwrap: false
+            }
+          )
+        ).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              "src/__tests__/fixture/_tmp_in/invalid-open-attestation-document.json is not valid against open-attestation schema"
+            )
+          })
+        );
+        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+      });
+      it("should not issue document when given wrapped document without --unwrap", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, wrappedFileName),
+          path.resolve(__dirname, `${inputDirectoryName}/wrapped-open-attestation-document.json`)
+        );
+
+        await expect(
+          wrap(
+            path.resolve(__dirname, `${inputDirectoryName}/wrapped-open-attestation-document.json`),
+            outputDirectory,
+            {
+              version: "open-attestation/3.0",
+              unwrap: false
+            }
+          )
+        ).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              "src/__tests__/fixture/_tmp_in/wrapped-open-attestation-document.json is not valid against open-attestation schema"
+            )
+          })
+        );
+        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+      });
+
+      it("should issue document when the given wrapped document and --unwrap is specified", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, wrappedFileName),
+          path.resolve(__dirname, `${inputDirectoryName}/wrapped-open-attestation-document.json`)
+        );
+
+        const merkleRoot = await wrap(
+          path.resolve(__dirname, `${inputDirectoryName}/wrapped-open-attestation-document.json`),
+          outputDirectory,
+          {
+            version: "open-attestation/3.0",
+            unwrap: true
+          }
+        );
+
+        const file = JSON.parse(
+          fs.readFileSync(`${outputDirectory}/wrapped-open-attestation-document.json`, { encoding: "utf8" })
+        );
+
+        expect(merkleRoot).toHaveLength(64);
+        expect(merkleRoot).toStrictEqual(file.signature.merkleRoot);
+        expect(merkleRoot).toStrictEqual(file.signature.targetHash);
+      });
+    });
+    describe("with schema", () => {
+      it("should not issue document when the given wrapped document and --unwrap is not specified", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, `${fixtureFolderName}/valid-custom-schema-document.json`),
+          path.resolve(__dirname, `${inputDirectoryName}/valid-custom-schema-document.json`)
+        );
+        const merkleRoot = await wrap(
+          path.resolve(__dirname, `${inputDirectoryName}/valid-custom-schema-document.json`),
+          outputDirectory,
+          {
+            schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
+            version: "open-attestation/3.0",
+            unwrap: false
+          }
+        );
+
+        const file = JSON.parse(
+          fs.readFileSync(`${outputDirectory}/valid-custom-schema-document.json`, { encoding: "utf8" })
+        );
+        expect(merkleRoot).toHaveLength(64);
+        expect(merkleRoot).toStrictEqual(file.signature.merkleRoot);
+        expect(merkleRoot).toStrictEqual(file.signature.targetHash);
+      });
+      it("should not issue document when given valid open attestation document that is not valid against the local schema provided", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, `${fixtureFolderName}/invalid-custom-schema-document.json`),
+          path.resolve(__dirname, `${inputDirectoryName}/invalid-custom-schema-document.json`)
+        );
+        await expect(
+          wrap(path.resolve(__dirname, `${inputDirectoryName}/invalid-custom-schema-document.json`), outputDirectory, {
+            schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
+            version: "open-attestation/3.0",
+            unwrap: false
+          })
+        ).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              "src/__tests__/fixture/_tmp_in/invalid-custom-schema-document.json is not valid against the provided schema"
+            )
+          })
+        );
+        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+      });
+      it("should issue document when given valid open attestation document that is also valid against the remote schema provided", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, `${fixtureFolderName}/valid-custom-schema-document.json`),
+          path.resolve(__dirname, `${inputDirectoryName}/valid-custom-schema-document.json`)
+        );
+        const merkleRoot = await wrap(
+          path.resolve(__dirname, `${inputDirectoryName}/valid-custom-schema-document.json`),
+          outputDirectory,
+          {
+            schemaPath:
+              "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
+            version: "open-attestation/3.0",
+            unwrap: false
+          }
+        );
+
+        const file = JSON.parse(
+          fs.readFileSync(`${outputDirectory}/valid-custom-schema-document.json`, { encoding: "utf8" })
+        );
+        expect(merkleRoot).toHaveLength(64);
+        expect(merkleRoot).toStrictEqual(file.signature.merkleRoot);
+        expect(merkleRoot).toStrictEqual(file.signature.targetHash);
+      });
+      it("should not issue document when given open attestation document that is not valid against the remote schema provided", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, `${fixtureFolderName}/invalid-custom-schema-document.json`),
+          path.resolve(__dirname, `${inputDirectoryName}/invalid-custom-schema-document.json`)
+        );
+        await expect(
+          wrap(path.resolve(__dirname, `${inputDirectoryName}/invalid-custom-schema-document.json`), outputDirectory, {
+            schemaPath:
+              "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
+            version: "open-attestation/3.0",
+            unwrap: false
+          })
+        ).rejects.toThrow(
+          expect.objectContaining({
+            message: expect.stringContaining(
+              "src/__tests__/fixture/_tmp_in/invalid-custom-schema-document.json is not valid against the provided schema"
+            )
+          })
+        );
+        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+      });
+      it("should not issue documents when schema is not valid", async () => {
+        fs.copyFileSync(
+          path.resolve(__dirname, `${fixtureFolderName}/valid-open-attestation-document.json`),
+          path.resolve(__dirname, `${inputDirectoryName}/valid-open-attestation-document.json`)
+        );
+        await expect(
+          wrap(path.resolve(__dirname, `${inputDirectoryName}/valid-open-attestation-document.json`), outputDirectory, {
             schemaPath: path.resolve(__dirname, fixtureFolderName, "invalid-schema.json"),
             version: "open-attestation/3.0",
             unwrap: false

--- a/src/__tests__/wrap.test.ts
+++ b/src/__tests__/wrap.test.ts
@@ -15,6 +15,8 @@ describe("batchIssue", () => {
         c: { sibling: "d", parent: "e" },
         d: { sibling: "c", parent: "e" }
       };
+      // @ts-ignore
+      jest.spyOn(fs, "lstatSync").mockReturnValue({ isDirectory: () => true });
       jest.spyOn(fs, "readdir").mockImplementation((options, callback) => {
         // @ts-ignore
         return callback(null, ["file_1.json", "file_2.json", "file_3.json"]);

--- a/src/commands/wrap.ts
+++ b/src/commands/wrap.ts
@@ -18,7 +18,7 @@ export const describe = "Wrap a directory of documents into a document batch";
 
 export const builder = (yargs: Argv): Argv =>
   yargs
-    .positional("ents-path", {
+    .positional("raw-documents-path", {
       description: "Directory containing the unissued raw documents or a single raw document file",
       normalize: true,
       type: "string"

--- a/src/commands/wrap.ts
+++ b/src/commands/wrap.ts
@@ -5,21 +5,21 @@ import { transformValidationErrors } from "../implementations/wrap/ajvErrorTrans
 import signale from "signale";
 
 interface WrapCommand {
-  rawDocumentsDir: string;
+  rawDocumentsPath: string;
   wrappedDocumentsDir: string;
   schema: any;
   openAttestationV3: boolean;
   unwrap: boolean;
 }
 
-export const command = "wrap <raw-documents-dir> <wrapped-documents-dir> [schema]";
+export const command = "wrap <raw-documents-path> <wrapped-documents-dir> [schema]";
 
 export const describe = "Wrap a directory of documents into a document batch";
 
 export const builder = (yargs: Argv): Argv =>
   yargs
-    .positional("raw-documents-dir", {
-      description: "Directory containing the unissued raw documents",
+    .positional("ents-path", {
+      description: "Directory containing the unissued raw documents or a single raw document file",
       normalize: true,
       type: "string"
     })
@@ -50,7 +50,7 @@ export const builder = (yargs: Argv): Argv =>
 
 export const handler = async (args: WrapCommand): Promise<string> => {
   try {
-    const merkleRoot = await wrap(args.rawDocumentsDir, args.wrappedDocumentsDir, {
+    const merkleRoot = await wrap(args.rawDocumentsPath, args.wrappedDocumentsDir, {
       schemaPath: args.schema,
       version: args.openAttestationV3 ? "open-attestation/3.0" : "open-attestation/2.0",
       unwrap: args.unwrap

--- a/src/implementations/wrap/diskUtils.ts
+++ b/src/implementations/wrap/diskUtils.ts
@@ -4,15 +4,29 @@ import util from "util";
 
 const readdir = util.promisify(fs.readdir);
 
+export const isDir = (path: fs.PathLike): boolean => {
+  try {
+    const stat = fs.lstatSync(path);
+    return stat.isDirectory();
+  } catch (e) {
+    return false;
+  }
+};
+
 const validExtensions = [/(.*)(\.)(opencert)$/, /(.*)(\.)(json)$/];
 
-export const readDocumentFile = (directory: string, filename: string): any =>
-  JSON.parse(fs.readFileSync(path.join(directory, filename), "utf8"));
+export const readDocumentFile = (filename: string): any => {
+  return JSON.parse(fs.readFileSync(filename, "utf8"));
+};
 
 const isValidExtension = (filename: string): boolean => validExtensions.some(mask => mask.test(filename.toLowerCase()));
 
-export const documentsInDirectory = async (dir: fs.PathLike): Promise<string[]> => {
-  const items = await readdir(dir);
+// this function return the list of path to the documents to process
+// only documents with valid extension are returned (opencerts, json)
+export const documentsInDirectory = async (documentPath: string): Promise<string[]> => {
+  const items = isDir(documentPath)
+    ? (await readdir(documentPath)).map(filename => path.join(documentPath, filename))
+    : [documentPath];
   return items.filter(isValidExtension);
 };
 


### PR DESCRIPTION
https://github.com/Open-Attestation/open-attestation-cli/issues/26

What i tried:
Implementing directory or file identification before the function call instead of within the function as in https://github.com/Open-Attestation/open-attestation-cli/pull/33/commits/92d89f58c1951c7c4163751c1f39464a3f4f2223

This causes the test to work but i am unable to get https://github.com/Open-Attestation/open-attestation-cli/issues/26 resolved as i could previously.

Right now:
I have reverted back the  directory or file identification within the function call.

https://github.com/Open-Attestation/open-attestation-cli/issues/26 has been resolved.

However i am unable to get wrap.test.ts to pass all tests.

Error:     TypeError: (0 , _diskUtils.isDir) is not a function