### PR TITLE
test: fix wrap e2e test

### DIFF
--- a/src/__tests__/wrap.e2e.test.ts
+++ b/src/__tests__/wrap.e2e.test.ts
@@ -4,18 +4,26 @@ import path from "path";
 import rimraf from "rimraf";
 
 const fixtureFolderName = "fixture";
-const inputDirectoryName = `${fixtureFolderName}/_tmp_in`;
-const outputDirectoryName = `${fixtureFolderName}/_tmp_out`;
 const validFileName = `${fixtureFolderName}/valid-open-attestation-document.json`;
 const invalidFileName = `${fixtureFolderName}/invalid-open-attestation-document.json`;
 const wrappedFileName = `${fixtureFolderName}/wrapped-open-attestation-document.json`;
+
+const inputDirectoryName = `${fixtureFolderName}/_tmp_in`;
+const outputDirectoryName = `${fixtureFolderName}/_tmp_out`;
 const inputDirectory = path.resolve(__dirname, inputDirectoryName);
 const outputDirectory = path.resolve(__dirname, outputDirectoryName);
+
+const inputDirectoryNameTwo = `${fixtureFolderName}/_tmp_in_two`;
+const outputDirectoryNameTwo = `${fixtureFolderName}/_tmp_out_two`;
+const inputDirectoryTwo = path.resolve(__dirname, inputDirectoryNameTwo);
+const outputDirectoryTwo = path.resolve(__dirname, outputDirectoryNameTwo);
 
 describe("wrap", () => {
   describe("wrap with directory input", () => {
     // eslint-disable-next-line jest/no-hooks
     beforeEach(() => {
+      rimraf.sync(inputDirectory);
+      rimraf.sync(outputDirectory);
       fs.mkdirSync(inputDirectory);
       fs.mkdirSync(outputDirectory);
     });
@@ -32,7 +40,8 @@ describe("wrap", () => {
         );
         const merkleRoot = await wrap(inputDirectory, outputDirectory, {
           version: "open-attestation/3.0",
-          unwrap: false
+          unwrap: false,
+          outputPathType: "directory"
         });
 
         const file = JSON.parse(
@@ -57,7 +66,8 @@ describe("wrap", () => {
         );
         const merkleRoot = await wrap(inputDirectory, outputDirectory, {
           version: "open-attestation/3.0",
-          unwrap: false
+          unwrap: false,
+          outputPathType: "directory"
         });
         const file1 = JSON.parse(
           fs.readFileSync(`${outputDirectory}/valid-open-attestation-document-1.json`, { encoding: "utf8" })
@@ -86,7 +96,11 @@ describe("wrap", () => {
         );
 
         await expect(
-          wrap(inputDirectory, outputDirectory, { version: "open-attestation/3.0", unwrap: false })
+          wrap(inputDirectory, outputDirectory, {
+            version: "open-attestation/3.0",
+            unwrap: false,
+            outputPathType: "directory"
+          })
         ).rejects.toThrow(
           expect.objectContaining({
             message: expect.stringContaining(
@@ -111,7 +125,11 @@ describe("wrap", () => {
         );
 
         await expect(
-          wrap(inputDirectory, outputDirectory, { version: "open-attestation/3.0", unwrap: false })
+          wrap(inputDirectory, outputDirectory, {
+            version: "open-attestation/3.0",
+            unwrap: false,
+            outputPathType: "directory"
+          })
         ).rejects.toThrow(
           expect.objectContaining({
             message: expect.stringContaining(
@@ -130,7 +148,8 @@ describe("wrap", () => {
         await expect(
           wrap(inputDirectory, outputDirectory, {
             version: "open-attestation/3.0",
-            unwrap: false
+            unwrap: false,
+            outputPathType: "directory"
           })
         ).rejects.toThrow(
           expect.objectContaining({
@@ -150,7 +169,8 @@ describe("wrap", () => {
 
         const merkleRoot = await wrap(inputDirectory, outputDirectory, {
           version: "open-attestation/3.0",
-          unwrap: true
+          unwrap: true,
+          outputPathType: "directory"
         });
 
         const file = JSON.parse(
@@ -171,7 +191,8 @@ describe("wrap", () => {
         const merkleRoot = await wrap(inputDirectory, outputDirectory, {
           schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
           version: "open-attestation/3.0",
-          unwrap: false
+          unwrap: false,
+          outputPathType: "directory"
         });
 
         const file = JSON.parse(
@@ -190,7 +211,8 @@ describe("wrap", () => {
           wrap(inputDirectory, outputDirectory, {
             schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
             version: "open-attestation/3.0",
-            unwrap: false
+            unwrap: false,
+            outputPathType: "directory"
           })
         ).rejects.toThrow(
           expect.objectContaining({
@@ -210,7 +232,8 @@ describe("wrap", () => {
           schemaPath:
             "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
           version: "open-attestation/3.0",
-          unwrap: false
+          unwrap: false,
+          outputPathType: "directory"
         });
 
         const file = JSON.parse(
@@ -230,7 +253,8 @@ describe("wrap", () => {
             schemaPath:
               "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
             version: "open-attestation/3.0",
-            unwrap: false
+            unwrap: false,
+            outputPathType: "directory"
           })
         ).rejects.toThrow(
           expect.objectContaining({
@@ -246,42 +270,49 @@ describe("wrap", () => {
           wrap(inputDirectory, outputDirectory, {
             schemaPath: path.resolve(__dirname, fixtureFolderName, "invalid-schema.json"),
             version: "open-attestation/3.0",
-            unwrap: false
+            unwrap: false,
+            outputPathType: "directory"
           })
         ).rejects.toThrow("Invalid schema, you must provide an $id property to your schema");
         expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
       });
     });
+
+    rimraf.sync(inputDirectory);
+    rimraf.sync(outputDirectory);
   });
 
   describe("wrap with file input", () => {
     // eslint-disable-next-line jest/no-hooks
     beforeEach(() => {
-      fs.mkdirSync(inputDirectory);
-      fs.mkdirSync(outputDirectory);
+      rimraf.sync(inputDirectoryTwo);
+      rimraf.sync(outputDirectoryTwo);
+      fs.mkdirSync(inputDirectoryTwo);
+      fs.mkdirSync(outputDirectoryTwo);
     });
     // eslint-disable-next-line jest/no-hooks
     afterEach(() => {
-      rimraf.sync(inputDirectory);
-      rimraf.sync(outputDirectory);
+      rimraf.sync(inputDirectoryTwo);
+      rimraf.sync(outputDirectoryTwo);
     });
     describe("without schema", () => {
       it("should issue document when given valid open attestation document", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, validFileName),
-          path.resolve(__dirname, `${inputDirectoryName}/valid-open-attestation-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/valid-open-attestation-document.json`)
         );
         const merkleRoot = await wrap(
-          path.resolve(__dirname, `${inputDirectoryName}/valid-open-attestation-document.json`),
-          outputDirectory,
+          path.resolve(__dirname, `${inputDirectoryTwo}/valid-open-attestation-document.json`),
+          outputDirectoryTwo,
           {
             version: "open-attestation/3.0",
-            unwrap: false
+            unwrap: false,
+            outputPathType: "directory"
           }
         );
 
         const file = JSON.parse(
-          fs.readFileSync(`${outputDirectory}/valid-open-attestation-document.json`, { encoding: "utf8" })
+          fs.readFileSync(`${outputDirectoryTwo}/valid-open-attestation-document.json`, { encoding: "utf8" })
         );
         expect(merkleRoot).toHaveLength(64);
         expect(merkleRoot).toStrictEqual(file.signature.merkleRoot);
@@ -290,69 +321,72 @@ describe("wrap", () => {
       it("should not issue document when given invalid open attestation document", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, invalidFileName),
-          path.resolve(__dirname, `${inputDirectoryName}/invalid-open-attestation-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/invalid-open-attestation-document.json`)
         );
 
         await expect(
           wrap(
-            path.resolve(__dirname, `${inputDirectoryName}/invalid-open-attestation-document.json`),
-            outputDirectory,
+            path.resolve(__dirname, `${inputDirectoryTwo}/invalid-open-attestation-document.json`),
+            outputDirectoryTwo,
             {
               version: "open-attestation/3.0",
-              unwrap: false
+              unwrap: false,
+              outputPathType: "directory"
             }
           )
         ).rejects.toThrow(
           expect.objectContaining({
             message: expect.stringContaining(
-              "src/__tests__/fixture/_tmp_in/invalid-open-attestation-document.json is not valid against open-attestation schema"
+              "src/__tests__/fixture/_tmp_in_two/invalid-open-attestation-document.json is not valid against open-attestation schema"
             )
           })
         );
-        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+        expect(fs.readdirSync(outputDirectoryTwo)).toHaveLength(0);
       });
       it("should not issue document when given wrapped document without --unwrap", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, wrappedFileName),
-          path.resolve(__dirname, `${inputDirectoryName}/wrapped-open-attestation-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/wrapped-open-attestation-document.json`)
         );
 
         await expect(
           wrap(
-            path.resolve(__dirname, `${inputDirectoryName}/wrapped-open-attestation-document.json`),
-            outputDirectory,
+            path.resolve(__dirname, `${inputDirectoryTwo}/wrapped-open-attestation-document.json`),
+            outputDirectoryTwo,
             {
               version: "open-attestation/3.0",
-              unwrap: false
+              unwrap: false,
+              outputPathType: "directory"
             }
           )
         ).rejects.toThrow(
           expect.objectContaining({
             message: expect.stringContaining(
-              "src/__tests__/fixture/_tmp_in/wrapped-open-attestation-document.json is not valid against open-attestation schema"
+              "src/__tests__/fixture/_tmp_in_two/wrapped-open-attestation-document.json is not valid against open-attestation schema"
             )
           })
         );
-        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+        expect(fs.readdirSync(outputDirectoryTwo)).toHaveLength(0);
       });
 
       it("should issue document when the given wrapped document and --unwrap is specified", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, wrappedFileName),
-          path.resolve(__dirname, `${inputDirectoryName}/wrapped-open-attestation-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/wrapped-open-attestation-document.json`)
         );
 
         const merkleRoot = await wrap(
-          path.resolve(__dirname, `${inputDirectoryName}/wrapped-open-attestation-document.json`),
-          outputDirectory,
+          path.resolve(__dirname, `${inputDirectoryTwo}/wrapped-open-attestation-document.json`),
+          outputDirectoryTwo,
           {
             version: "open-attestation/3.0",
-            unwrap: true
+            unwrap: true,
+            outputPathType: "directory"
           }
         );
 
         const file = JSON.parse(
-          fs.readFileSync(`${outputDirectory}/wrapped-open-attestation-document.json`, { encoding: "utf8" })
+          fs.readFileSync(`${outputDirectoryTwo}/wrapped-open-attestation-document.json`, { encoding: "utf8" })
         );
 
         expect(merkleRoot).toHaveLength(64);
@@ -364,20 +398,21 @@ describe("wrap", () => {
       it("should not issue document when the given wrapped document and --unwrap is not specified", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, `${fixtureFolderName}/valid-custom-schema-document.json`),
-          path.resolve(__dirname, `${inputDirectoryName}/valid-custom-schema-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/valid-custom-schema-document.json`)
         );
         const merkleRoot = await wrap(
-          path.resolve(__dirname, `${inputDirectoryName}/valid-custom-schema-document.json`),
-          outputDirectory,
+          path.resolve(__dirname, `${inputDirectoryTwo}/valid-custom-schema-document.json`),
+          outputDirectoryTwo,
           {
             schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
             version: "open-attestation/3.0",
-            unwrap: false
+            unwrap: false,
+            outputPathType: "directory"
           }
         );
 
         const file = JSON.parse(
-          fs.readFileSync(`${outputDirectory}/valid-custom-schema-document.json`, { encoding: "utf8" })
+          fs.readFileSync(`${outputDirectoryTwo}/valid-custom-schema-document.json`, { encoding: "utf8" })
         );
         expect(merkleRoot).toHaveLength(64);
         expect(merkleRoot).toStrictEqual(file.signature.merkleRoot);
@@ -386,41 +421,47 @@ describe("wrap", () => {
       it("should not issue document when given valid open attestation document that is not valid against the local schema provided", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, `${fixtureFolderName}/invalid-custom-schema-document.json`),
-          path.resolve(__dirname, `${inputDirectoryName}/invalid-custom-schema-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/invalid-custom-schema-document.json`)
         );
         await expect(
-          wrap(path.resolve(__dirname, `${inputDirectoryName}/invalid-custom-schema-document.json`), outputDirectory, {
-            schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
-            version: "open-attestation/3.0",
-            unwrap: false
-          })
+          wrap(
+            path.resolve(__dirname, `${inputDirectoryTwo}/invalid-custom-schema-document.json`),
+            outputDirectoryTwo,
+            {
+              schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
+              version: "open-attestation/3.0",
+              unwrap: false,
+              outputPathType: "directory"
+            }
+          )
         ).rejects.toThrow(
           expect.objectContaining({
             message: expect.stringContaining(
-              "src/__tests__/fixture/_tmp_in/invalid-custom-schema-document.json is not valid against the provided schema"
+              "src/__tests__/fixture/_tmp_in_two/invalid-custom-schema-document.json is not valid against the provided schema"
             )
           })
         );
-        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+        expect(fs.readdirSync(outputDirectoryTwo)).toHaveLength(0);
       });
       it("should issue document when given valid open attestation document that is also valid against the remote schema provided", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, `${fixtureFolderName}/valid-custom-schema-document.json`),
-          path.resolve(__dirname, `${inputDirectoryName}/valid-custom-schema-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/valid-custom-schema-document.json`)
         );
         const merkleRoot = await wrap(
-          path.resolve(__dirname, `${inputDirectoryName}/valid-custom-schema-document.json`),
-          outputDirectory,
+          path.resolve(__dirname, `${inputDirectoryTwo}/valid-custom-schema-document.json`),
+          outputDirectoryTwo,
           {
             schemaPath:
               "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
             version: "open-attestation/3.0",
-            unwrap: false
+            unwrap: false,
+            outputPathType: "directory"
           }
         );
 
         const file = JSON.parse(
-          fs.readFileSync(`${outputDirectory}/valid-custom-schema-document.json`, { encoding: "utf8" })
+          fs.readFileSync(`${outputDirectoryTwo}/valid-custom-schema-document.json`, { encoding: "utf8" })
         );
         expect(merkleRoot).toHaveLength(64);
         expect(merkleRoot).toStrictEqual(file.signature.merkleRoot);
@@ -429,38 +470,51 @@ describe("wrap", () => {
       it("should not issue document when given open attestation document that is not valid against the remote schema provided", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, `${fixtureFolderName}/invalid-custom-schema-document.json`),
-          path.resolve(__dirname, `${inputDirectoryName}/invalid-custom-schema-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/invalid-custom-schema-document.json`)
         );
         await expect(
-          wrap(path.resolve(__dirname, `${inputDirectoryName}/invalid-custom-schema-document.json`), outputDirectory, {
-            schemaPath:
-              "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
-            version: "open-attestation/3.0",
-            unwrap: false
-          })
+          wrap(
+            path.resolve(__dirname, `${inputDirectoryTwo}/invalid-custom-schema-document.json`),
+            outputDirectoryTwo,
+            {
+              schemaPath:
+                "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
+              version: "open-attestation/3.0",
+              unwrap: false,
+              outputPathType: "directory"
+            }
+          )
         ).rejects.toThrow(
           expect.objectContaining({
             message: expect.stringContaining(
-              "src/__tests__/fixture/_tmp_in/invalid-custom-schema-document.json is not valid against the provided schema"
+              "src/__tests__/fixture/_tmp_in_two/invalid-custom-schema-document.json is not valid against the provided schema"
             )
           })
         );
-        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+        expect(fs.readdirSync(outputDirectoryTwo)).toHaveLength(0);
       });
       it("should not issue documents when schema is not valid", async () => {
         fs.copyFileSync(
           path.resolve(__dirname, `${fixtureFolderName}/valid-open-attestation-document.json`),
-          path.resolve(__dirname, `${inputDirectoryName}/valid-open-attestation-document.json`)
+          path.resolve(__dirname, `${inputDirectoryNameTwo}/valid-open-attestation-document.json`)
         );
         await expect(
-          wrap(path.resolve(__dirname, `${inputDirectoryName}/valid-open-attestation-document.json`), outputDirectory, {
-            schemaPath: path.resolve(__dirname, fixtureFolderName, "invalid-schema.json"),
-            version: "open-attestation/3.0",
-            unwrap: false
-          })
+          wrap(
+            path.resolve(__dirname, `${inputDirectoryTwo}/valid-open-attestation-document.json`),
+            outputDirectoryTwo,
+            {
+              schemaPath: path.resolve(__dirname, fixtureFolderName, "invalid-schema.json"),
+              version: "open-attestation/3.0",
+              unwrap: false,
+              outputPathType: "directory"
+            }
+          )
         ).rejects.toThrow("Invalid schema, you must provide an $id property to your schema");
-        expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
+        expect(fs.readdirSync(outputDirectoryTwo)).toHaveLength(0);
       });
     });
+
+    rimraf.sync(inputDirectoryTwo);
+    rimraf.sync(outputDirectoryTwo);
   });
 });

--- a/src/__tests__/wrap.e2e.test.ts
+++ b/src/__tests__/wrap.e2e.test.ts
@@ -13,6 +13,7 @@ const outputDirectoryName = `${fixtureFolderName}/_tmp_out`;
 const inputDirectory = path.resolve(__dirname, inputDirectoryName);
 const outputDirectory = path.resolve(__dirname, outputDirectoryName);
 
+// separate set of temp folders use for second test to prevent race condition between rimraf
 const inputDirectoryNameTwo = `${fixtureFolderName}/_tmp_in_two`;
 const outputDirectoryNameTwo = `${fixtureFolderName}/_tmp_out_two`;
 const inputDirectoryTwo = path.resolve(__dirname, inputDirectoryNameTwo);
@@ -266,9 +267,6 @@ describe("wrap", () => {
         expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
       });
     });
-
-    rimraf.sync(inputDirectory);
-    rimraf.sync(outputDirectory);
   });
 
   describe("wrap with file input", () => {
@@ -493,8 +491,5 @@ describe("wrap", () => {
         expect(fs.readdirSync(outputDirectoryTwo)).toHaveLength(0);
       });
     });
-
-    rimraf.sync(inputDirectoryTwo);
-    rimraf.sync(outputDirectoryTwo);
   });
 });

--- a/src/__tests__/wrap.e2e.test.ts
+++ b/src/__tests__/wrap.e2e.test.ts
@@ -40,8 +40,7 @@ describe("wrap", () => {
         );
         const merkleRoot = await wrap(inputDirectory, outputDirectory, {
           version: "open-attestation/3.0",
-          unwrap: false,
-          outputPathType: "directory"
+          unwrap: false
         });
 
         const file = JSON.parse(
@@ -66,8 +65,7 @@ describe("wrap", () => {
         );
         const merkleRoot = await wrap(inputDirectory, outputDirectory, {
           version: "open-attestation/3.0",
-          unwrap: false,
-          outputPathType: "directory"
+          unwrap: false
         });
         const file1 = JSON.parse(
           fs.readFileSync(`${outputDirectory}/valid-open-attestation-document-1.json`, { encoding: "utf8" })
@@ -98,8 +96,7 @@ describe("wrap", () => {
         await expect(
           wrap(inputDirectory, outputDirectory, {
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           })
         ).rejects.toThrow(
           expect.objectContaining({
@@ -127,8 +124,7 @@ describe("wrap", () => {
         await expect(
           wrap(inputDirectory, outputDirectory, {
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           })
         ).rejects.toThrow(
           expect.objectContaining({
@@ -148,8 +144,7 @@ describe("wrap", () => {
         await expect(
           wrap(inputDirectory, outputDirectory, {
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           })
         ).rejects.toThrow(
           expect.objectContaining({
@@ -169,8 +164,7 @@ describe("wrap", () => {
 
         const merkleRoot = await wrap(inputDirectory, outputDirectory, {
           version: "open-attestation/3.0",
-          unwrap: true,
-          outputPathType: "directory"
+          unwrap: true
         });
 
         const file = JSON.parse(
@@ -191,8 +185,7 @@ describe("wrap", () => {
         const merkleRoot = await wrap(inputDirectory, outputDirectory, {
           schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
           version: "open-attestation/3.0",
-          unwrap: false,
-          outputPathType: "directory"
+          unwrap: false
         });
 
         const file = JSON.parse(
@@ -211,8 +204,7 @@ describe("wrap", () => {
           wrap(inputDirectory, outputDirectory, {
             schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           })
         ).rejects.toThrow(
           expect.objectContaining({
@@ -232,8 +224,7 @@ describe("wrap", () => {
           schemaPath:
             "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
           version: "open-attestation/3.0",
-          unwrap: false,
-          outputPathType: "directory"
+          unwrap: false
         });
 
         const file = JSON.parse(
@@ -253,8 +244,7 @@ describe("wrap", () => {
             schemaPath:
               "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           })
         ).rejects.toThrow(
           expect.objectContaining({
@@ -270,8 +260,7 @@ describe("wrap", () => {
           wrap(inputDirectory, outputDirectory, {
             schemaPath: path.resolve(__dirname, fixtureFolderName, "invalid-schema.json"),
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           })
         ).rejects.toThrow("Invalid schema, you must provide an $id property to your schema");
         expect(fs.readdirSync(outputDirectory)).toHaveLength(0);
@@ -306,8 +295,7 @@ describe("wrap", () => {
           outputDirectoryTwo,
           {
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           }
         );
 
@@ -330,8 +318,7 @@ describe("wrap", () => {
             outputDirectoryTwo,
             {
               version: "open-attestation/3.0",
-              unwrap: false,
-              outputPathType: "directory"
+              unwrap: false
             }
           )
         ).rejects.toThrow(
@@ -355,8 +342,7 @@ describe("wrap", () => {
             outputDirectoryTwo,
             {
               version: "open-attestation/3.0",
-              unwrap: false,
-              outputPathType: "directory"
+              unwrap: false
             }
           )
         ).rejects.toThrow(
@@ -380,8 +366,7 @@ describe("wrap", () => {
           outputDirectoryTwo,
           {
             version: "open-attestation/3.0",
-            unwrap: true,
-            outputPathType: "directory"
+            unwrap: true
           }
         );
 
@@ -406,8 +391,7 @@ describe("wrap", () => {
           {
             schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           }
         );
 
@@ -430,8 +414,7 @@ describe("wrap", () => {
             {
               schemaPath: path.resolve(__dirname, fixtureFolderName, "schema.json"),
               version: "open-attestation/3.0",
-              unwrap: false,
-              outputPathType: "directory"
+              unwrap: false
             }
           )
         ).rejects.toThrow(
@@ -455,8 +438,7 @@ describe("wrap", () => {
             schemaPath:
               "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
             version: "open-attestation/3.0",
-            unwrap: false,
-            outputPathType: "directory"
+            unwrap: false
           }
         );
 
@@ -480,8 +462,7 @@ describe("wrap", () => {
               schemaPath:
                 "https://gist.githubusercontent.com/Nebulis/dd8198ab76443489e14121dad225d351/raw/693b50a1694942fb3cc6a8dcf5187cc7c75adb58/schema.json",
               version: "open-attestation/3.0",
-              unwrap: false,
-              outputPathType: "directory"
+              unwrap: false
             }
           )
         ).rejects.toThrow(
@@ -505,8 +486,7 @@ describe("wrap", () => {
             {
               schemaPath: path.resolve(__dirname, fixtureFolderName, "invalid-schema.json"),
               version: "open-attestation/3.0",
-              unwrap: false,
-              outputPathType: "directory"
+              unwrap: false
             }
           )
         ).rejects.toThrow("Invalid schema, you must provide an $id property to your schema");


### PR DESCRIPTION
- Wrong variable used for tests for file as input: inputDirectoryName => inputDirectory (inputDirectoryTwo)

- Tests fail sometime => because the test for file as input and the test for directory as input uses the same temporary folder tmp_in, hence when the tests run out of order, the two tests interleave causing race condition between the rimraf operations. This results in the folders not being cleared properly, causing futher tests to face errors such as 'folder already exists'.
=> separate tmp_in_two used

