### PR TITLE
feat: dry run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8669,9 +8669,9 @@
       }
     },
     "ethers": {
-      "version": "4.0.46",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.46.tgz",
-      "integrity": "sha512-/dPMzzpInhtiip4hKFvsDiJKeRk64IhyA+Po7CtNXneQFSOCYXg8eBFt+jXbxUQyApgWnWOtYxWdfn9+CvvxDA==",
+      "version": "4.0.47",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.47.tgz",
+      "integrity": "sha512-hssRYhngV4hiDNeZmVU/k5/E8xmLG8UpcNUzg6mb7lqhgpFPH/t7nuv20RjRrEf0gblzvi2XwR5Te+V3ZFc9pQ==",
       "requires": {
         "aes-js": "3.0.0",
         "bn.js": "^4.4.0",

--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -15,6 +15,7 @@ export interface WalletOption extends PrivateKeyOption {
 
 export interface GasOption {
   gasPriceScale: number;
+  dryRun: boolean;
 }
 
 export interface NetworkAndKeyOption extends NetworkOption, WalletOption {}
@@ -27,12 +28,19 @@ export const withNetworkOption = (yargs: Argv): Argv =>
     description: "Ethereum network to deploy to",
   });
 export const withGasPriceOption = (yargs: Argv): Argv =>
-  yargs.option("gas-price-scale", {
-    alias: "gps",
-    type: "number",
-    default: 1,
-    description: "Gas price scale to apply to the estimated gas price",
-  });
+  yargs
+    .option("gas-price-scale", {
+      alias: "gps",
+      type: "number",
+      default: 1,
+      description: "Gas price scale to apply to the estimated gas price",
+    })
+    .option("dry-run", {
+      alias: "dr",
+      type: "boolean",
+      default: false,
+      description: "Dry run",
+    });
 
 export const withPrivateKeyOption = (yargs: Argv): Argv =>
   yargs

--- a/src/implementations/deploy/document-store/document-store.test.ts
+++ b/src/implementations/deploy/document-store/document-store.test.ts
@@ -11,6 +11,7 @@ const deployParams: DeployDocumentStoreCommand = {
   network: "ropsten",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
+  dryRun: false,
 };
 
 describe("document-store", () => {
@@ -36,6 +37,7 @@ describe("document-store", () => {
         storeName: "Test",
         network: "ropsten",
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedDocumentStoreFactory.mock.calls[0][0];
@@ -48,6 +50,7 @@ describe("document-store", () => {
         network: "ropsten",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedDocumentStoreFactory.mock.calls[0][0];
@@ -77,6 +80,7 @@ describe("document-store", () => {
           storeName: "Test",
           network: "ropsten",
           gasPriceScale: 1,
+          dryRun: false,
         })
       ).rejects.toThrow(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path"

--- a/src/implementations/deploy/document-store/document-store.ts
+++ b/src/implementations/deploy/document-store/document-store.ts
@@ -3,6 +3,7 @@ import signale from "signale";
 import { DeployDocumentStoreCommand } from "../../../commands/deploy/deploy.types";
 import { getLogger } from "../../../logger";
 import { getWallet } from "../../utils/wallet";
+import { dryRunMode } from "../../utils/dryRun";
 
 const { trace } = getLogger("deploy:document-store");
 
@@ -12,8 +13,18 @@ export const deployDocumentStore = async ({
   key,
   keyFile,
   gasPriceScale,
+  dryRun,
   encryptedWalletPath,
 }: DeployDocumentStoreCommand): Promise<{ contractAddress: string }> => {
+  if (dryRun) {
+    await dryRunMode({
+      gasPriceScale: gasPriceScale,
+      transaction: new DocumentStoreFactory().getDeployTransaction(storeName),
+      network,
+    });
+    process.exit(0);
+  }
+
   const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
   const gasPrice = await wallet.provider.getGasPrice();
   const factory = new DocumentStoreFactory(wallet);

--- a/src/implementations/deploy/title-escrow-creator/title-escrow-creator.test.ts
+++ b/src/implementations/deploy/title-escrow-creator/title-escrow-creator.test.ts
@@ -10,6 +10,7 @@ const deployParams: DeployTitleEscrowCreatorCommand = {
   network: "ropsten",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
+  dryRun: false,
 };
 
 describe("token-registry", () => {
@@ -33,6 +34,7 @@ describe("token-registry", () => {
       await deployTitleEscrowCreator({
         network: "ropsten",
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedTokenFactory.mock.calls[0][0];
@@ -44,6 +46,7 @@ describe("token-registry", () => {
         network: "ropsten",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedTokenFactory.mock.calls[0][0];
@@ -72,6 +75,7 @@ describe("token-registry", () => {
         deployTitleEscrowCreator({
           network: "ropsten",
           gasPriceScale: 1,
+          dryRun: false,
         })
       ).rejects.toThrow(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path"

--- a/src/implementations/deploy/title-escrow-creator/title-escrow-creator.ts
+++ b/src/implementations/deploy/title-escrow-creator/title-escrow-creator.ts
@@ -4,6 +4,7 @@ import signale from "signale";
 import { getLogger } from "../../../logger";
 import { TransactionReceipt } from "ethers/providers";
 import { DeployTitleEscrowCreatorCommand } from "../../../commands/deploy/deploy.types";
+import { dryRunMode } from "../../utils/dryRun";
 
 const { trace } = getLogger("deploy:title-escrow-creator");
 
@@ -13,7 +14,17 @@ export const deployTitleEscrowCreator = async ({
   keyFile,
   gasPriceScale,
   encryptedWalletPath,
+  dryRun,
 }: DeployTitleEscrowCreatorCommand): Promise<TransactionReceipt> => {
+  if (dryRun) {
+    const factory = new TitleEscrowCreatorFactory();
+    await dryRunMode({
+      network,
+      gasPriceScale: gasPriceScale,
+      transaction: factory.getDeployTransaction(),
+    });
+    process.exit(0);
+  }
   const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
   const gasPrice = await wallet.provider.getGasPrice();
   const factory = new TitleEscrowCreatorFactory(wallet);

--- a/src/implementations/deploy/title-escrow/title-escrow.test.ts
+++ b/src/implementations/deploy/title-escrow/title-escrow.test.ts
@@ -14,6 +14,7 @@ const deployParams: DeployTitleEscrowCommand = {
   network: "ropsten",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
+  dryRun: false,
 };
 
 describe("token-registry", () => {
@@ -41,6 +42,7 @@ describe("token-registry", () => {
         titleEscrowFactory: "0x0000000000000000000000000000000000000003",
         network: "ropsten",
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedTokenFactory.mock.calls[0][0];
@@ -56,6 +58,7 @@ describe("token-registry", () => {
         titleEscrowFactory: "0x0000000000000000000000000000000000000003",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedTokenFactory.mock.calls[0][0];
@@ -92,6 +95,7 @@ describe("token-registry", () => {
           holder: "0x0000000000000000000000000000000000000002",
           titleEscrowFactory: "0x0000000000000000000000000000000000000003",
           gasPriceScale: 1,
+          dryRun: false,
         })
       ).rejects.toThrow(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path"

--- a/src/implementations/deploy/token-registry/token-registry.test.ts
+++ b/src/implementations/deploy/token-registry/token-registry.test.ts
@@ -12,6 +12,7 @@ const deployParams: DeployTokenRegistryCommand = {
   network: "ropsten",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
+  dryRun: false,
 };
 
 describe("token-registry", () => {
@@ -37,6 +38,7 @@ describe("token-registry", () => {
         registrySymbol: "Tst",
         network: "ropsten",
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedTokenFactory.mock.calls[0][0];
@@ -50,6 +52,7 @@ describe("token-registry", () => {
         network: "ropsten",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedTokenFactory.mock.calls[0][0];
@@ -82,6 +85,7 @@ describe("token-registry", () => {
           registrySymbol: "Tst",
           network: "ropsten",
           gasPriceScale: 1,
+          dryRun: false,
         })
       ).rejects.toThrow(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path"

--- a/src/implementations/deploy/token-registry/token-registry.ts
+++ b/src/implementations/deploy/token-registry/token-registry.ts
@@ -4,6 +4,7 @@ import signale from "signale";
 import { getLogger } from "../../../logger";
 import { TransactionReceipt } from "ethers/providers";
 import { DeployTokenRegistryCommand } from "../../../commands/deploy/deploy.types";
+import { dryRunMode } from "../../utils/dryRun";
 
 const { trace } = getLogger("deploy:token-registry");
 
@@ -15,7 +16,18 @@ export const deployTokenRegistry = async ({
   keyFile,
   gasPriceScale,
   encryptedWalletPath,
+  dryRun,
 }: DeployTokenRegistryCommand): Promise<TransactionReceipt> => {
+  if (dryRun) {
+    // TODO this does not work ?
+    const factory = new TradeTrustERC721Factory();
+    await dryRunMode({
+      network,
+      gasPriceScale: gasPriceScale,
+      transaction: factory.getDeployTransaction(registryName, registrySymbol, {}),
+    });
+    process.exit(0);
+  }
   const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
   const gasPrice = await wallet.provider.getGasPrice();
   const factory = new TradeTrustERC721Factory(wallet);

--- a/src/implementations/document-store/issue.test.ts
+++ b/src/implementations/document-store/issue.test.ts
@@ -12,6 +12,7 @@ const deployParams: DocumentStoreIssueCommand = {
   network: "ropsten",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
+  dryRun: false,
 };
 
 // TODO the following test is very fragile and might break on every interface change of DocumentStoreFactory
@@ -46,6 +47,7 @@ describe("document-store", () => {
         address: "0x1234",
         network: "ropsten",
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedConnect.mock.calls[0][1];
@@ -59,6 +61,7 @@ describe("document-store", () => {
         network: "ropsten",
         keyFile: join(__dirname, "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedConnect.mock.calls[0][1];
@@ -90,6 +93,7 @@ describe("document-store", () => {
           address: "0x1234",
           network: "ropsten",
           gasPriceScale: 1,
+          dryRun: false,
         })
       ).rejects.toThrow(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path"

--- a/src/implementations/document-store/revoke.test.ts
+++ b/src/implementations/document-store/revoke.test.ts
@@ -12,6 +12,7 @@ const deployParams: DocumentStoreRevokeCommand = {
   network: "ropsten",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
+  dryRun: false,
 };
 
 // TODO the following test is very fragile and might break on every interface change of DocumentStoreFactory
@@ -46,6 +47,7 @@ describe("document-store", () => {
         address: "0x1234",
         network: "ropsten",
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedConnect.mock.calls[0][1];
@@ -59,6 +61,7 @@ describe("document-store", () => {
         network: "ropsten",
         keyFile: join(__dirname, "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
+        dryRun: false,
       });
 
       const passedSigner: Wallet = mockedConnect.mock.calls[0][1];
@@ -90,6 +93,7 @@ describe("document-store", () => {
           address: "0x1234",
           network: "ropsten",
           gasPriceScale: 1,
+          dryRun: false,
         })
       ).rejects.toThrow(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path"

--- a/src/implementations/document-store/revoke.ts
+++ b/src/implementations/document-store/revoke.ts
@@ -3,6 +3,7 @@ import signale from "signale";
 import { getLogger } from "../../logger";
 import { DocumentStoreRevokeCommand } from "../../commands/document-store/document-store-command.type";
 import { getWallet } from "../utils/wallet";
+import { dryRunMode } from "../utils/dryRun";
 
 const { trace } = getLogger("document-store:revoke");
 
@@ -14,8 +15,18 @@ export const revokeToDocumentStore = async ({
   keyFile,
   gasPriceScale,
   encryptedWalletPath,
+  dryRun,
 }: DocumentStoreRevokeCommand): Promise<{ transactionHash: string }> => {
   const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
+  if (dryRun) {
+    const documentStore = await DocumentStoreFactory.connect(address, wallet);
+    await dryRunMode({
+      gasPriceScale: gasPriceScale,
+      estimatedGas: await documentStore.estimate.revoke(hash),
+      network,
+    });
+    process.exit(0);
+  }
   const gasPrice = await wallet.provider.getGasPrice();
   signale.await(`Sending transaction to pool`);
   const transaction = await DocumentStoreFactory.connect(address, wallet).revoke(hash, {

--- a/src/implementations/token-registry/issue.test.ts
+++ b/src/implementations/token-registry/issue.test.ts
@@ -12,6 +12,7 @@ const deployParams: TokenRegistryIssueCommand = {
   address: "0x1234",
   network: "ropsten",
   gasPriceScale: 1,
+  dryRun: false,
 };
 
 // TODO the following test is very fragile and might break on every interface change of TradeTrustERC721Factory

--- a/src/implementations/utils/dryRun.ts
+++ b/src/implementations/utils/dryRun.ts
@@ -1,0 +1,113 @@
+import { ethers, utils } from "ethers";
+import fetch from "node-fetch";
+import { green, highlight, red } from "../../utils";
+import { BigNumber, UnsignedTransaction } from "ethers/utils";
+
+export const dryRunMode = async ({
+  gasPriceScale,
+  transaction,
+  estimatedGas,
+  network,
+}: {
+  gasPriceScale: number;
+  network: string;
+  transaction?: UnsignedTransaction;
+  estimatedGas?: BigNumber;
+}): Promise<void> => {
+  // estimated gas or a transaction must be provided, if a transaction is provided let's estimate the gas automatically
+  // the transaction is run on the provided network
+  let _estimatedGas = estimatedGas;
+  if (!estimatedGas && transaction) {
+    const provider = ethers.getDefaultProvider(network);
+    _estimatedGas = await provider.estimateGas(transaction);
+  }
+  if (!_estimatedGas) {
+    throw new Error("Please provide estimatedGas or transaction");
+  }
+
+  // get gas price on mainnet
+  const { fast, fastest, safeLow, average } = await fetch("https://ethgasstation.info/api/ethgasAPI.json").then(
+    async (response) => {
+      if (response.ok) return response.json();
+      else {
+        throw new Error(`Unable to get gas price - ${response.statusText}`);
+      }
+    }
+  );
+  const gasPrice = await ethers.getDefaultProvider().getGasPrice();
+  const gasPriceAsGwei = Number(utils.formatUnits(gasPrice, "gwei"));
+  const convertGasApiToGwei = (value: number): number => value / 10;
+  const convertGweiToEthereum = (value: BigNumber): number =>
+    Number(utils.formatUnits(utils.parseUnits(`${value.toNumber()}`, "gwei"), "ether"));
+
+  console.log(red("\n\n/!\\ Welcome to the dry run mode. Please read the information below to understand the table"));
+  console.log(
+    `\nThe table below display information about the cost of the transaction on the mainnet network, depending on the gas price selected. Multiple modes are displayed to help you better help you to choose a gas price depending on your needs:
+- ${highlight("current")} mode display information depending on the current information provided to the cli.
+- ${highlight("fastest")} mode display information in order to run a transaction in less than 30s.
+- ${highlight("fast")} mode display information in order to run a transaction in less than 2 mins.
+- ${highlight("average")} mode display information in order to run a transaction in less than 5 mins.
+- ${highlight("safe")} mode display information in order to run a transaction in less than 30 mins.
+    
+For each mode the following information will be shown:
+- ${highlight("gas price (gwei)")}: the gas price in gwei used for the transaction.
+- ${highlight(
+      "tx price (gwei)"
+    )}: the price of the transaction in gwei. This is the amount payed for the transaction (outside of dry-run)
+- ${highlight(
+      "tx price (eth)"
+    )}: the price of the transaction in ethereum. This is the amount payed for the transaction (outside of dry-run). You can directly use that amount to convert it to your currency using any currency converter supporting ethereum.
+- ${highlight(
+      "gas price scale"
+    )}: this is an estimation of the value you must set for the '--gas-price-scale' parameter. Keep in mind that two successive runs will likely produce 2 different values as the gas price is fluctuating.
+
+Get more information about gas: https://ethereum.stackexchange.com/questions/3/what-is-meant-by-the-term-gas\n\n`
+  );
+
+  console.log(green("Information about the transaction:"));
+  console.log(
+    `Estimated gas required: ${highlight(
+      _estimatedGas.toNumber().toString(10)
+    )} gas, which will cost approximately ${highlight(
+      convertGweiToEthereum(_estimatedGas.mul(gasPriceAsGwei)).toString(10)
+    )} eth based on the selected gas price`
+  );
+  console.table({
+    current: {
+      time: "N/A",
+      "gas price (gwei)": gasPriceAsGwei * gasPriceScale,
+      "tx price (gwei)": _estimatedGas.mul(gasPriceAsGwei * gasPriceScale).toNumber(),
+      "tx price (eth)": convertGweiToEthereum(_estimatedGas.mul(gasPriceAsGwei * gasPriceScale)),
+      "gas price scale": gasPriceScale,
+    },
+    fastest: {
+      time: "< 30 s",
+      "gas price (gwei)": convertGasApiToGwei(fastest),
+      "tx price (gwei)": _estimatedGas.mul(convertGasApiToGwei(fastest)).toNumber(),
+      "tx price (eth)": convertGweiToEthereum(_estimatedGas.mul(convertGasApiToGwei(fastest))),
+      "gas price scale": Number((fastest / 10 / gasPriceAsGwei).toFixed(2)),
+    },
+    fast: {
+      time: "< 2 mins",
+      "gas price (gwei)": convertGasApiToGwei(fast),
+      "tx price (gwei)": _estimatedGas.mul(convertGasApiToGwei(fast)).toNumber(),
+      "tx price (eth)": convertGweiToEthereum(_estimatedGas.mul(convertGasApiToGwei(fast))),
+      "gas price scale": Number((fast / 10 / gasPriceAsGwei).toFixed(2)),
+    },
+    average: {
+      time: "< 5 mins",
+      "gas price (gwei)": convertGasApiToGwei(average),
+      "tx price (gwei)": _estimatedGas.mul(convertGasApiToGwei(average)).toNumber(),
+      "tx price (eth)": convertGweiToEthereum(_estimatedGas.mul(convertGasApiToGwei(average))),
+      "gas price scale": Number((average / 10 / gasPriceAsGwei).toFixed(2)),
+    },
+    safe: {
+      time: "< 30 mins",
+      "gas price (gwei)": convertGasApiToGwei(safeLow),
+      "tx price (gwei)": _estimatedGas.mul(convertGasApiToGwei(safeLow)).toNumber(),
+      "tx price (eth)": convertGweiToEthereum(_estimatedGas.mul(convertGasApiToGwei(safeLow))),
+      "gas price scale": Number((safeLow / 10 / gasPriceAsGwei).toFixed(2)),
+    },
+  });
+  console.log(red("Please read the information above to understand the table"));
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,5 @@ export const getEtherscanAddress = ({ network }: { network: string }): string =>
 
 const orange = chalk.hsl(39, 100, 50);
 export const highlight = orange.bold;
+export const red = chalk.hsl(360, 100, 50).bold;
+export const green = chalk.hsl(123, 100, 50).bold;


### PR DESCRIPTION
Run transaction using dry-run to get information about the cost. Use `--dry-run` on any command needing a transaction.

In order to work, the transaction must be valid on the network you selected (otherwise it will fail) and the result is displayed depending on `mainnet` network price, whatever network you run the transaction on. (gas needed is not dependent of the network)

Currently deploying a token registry does not work:
- https://community.infura.io/t/eth-estimategas-always-fail-on-a-specific-contract/1801
- https://community.cloudflare.com/t/cloudflare-ethereum-eth-estimategas/192306