### PR TITLE
chore: added oa ext

### DIFF
--- a/src/implementations/utils/disk.ts
+++ b/src/implementations/utils/disk.ts
@@ -13,7 +13,7 @@ export const isDir = (path: fs.PathLike): boolean => {
   }
 };
 
-const validExtensions = /(.*)(\.)(opencerts?|json|jsonld|tt)$/;
+const validExtensions = /(.*)(\.)(opencerts?|json|jsonld|tt|oa)$/;
 
 export const readFile = (filename: string): any => {
   return fs.readFileSync(filename, "utf8");


### PR DESCRIPTION
Issues : Unable to detect .oa unwrapped files
Problem: Failed validation check due to .oa not in valid ext
Solution: Added .oa to valid ext