### PR TITLE
fix: update token registry package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3490,9 +3490,9 @@
       }
     },
     "@govtechsg/token-registry": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@govtechsg/token-registry/-/token-registry-2.5.0.tgz",
-      "integrity": "sha512-zmROyuJ96Gnmrqdj2mO9O1EzBAPjBb89byhMFWzyEb+GeXe3w4UPuwwJp0/t297TmPgZm0UGaCmncuIpIxS8Mw=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@govtechsg/token-registry/-/token-registry-2.5.1.tgz",
+      "integrity": "sha512-OT5oPHz6ENKhyqAdkWJX3AZcD/tVwbAtm+snfBE8e3i1kw7eciEQIPC1sXiAwm51o1F/6qgU+6/VFaGQx1u5uA=="
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@govtechsg/document-store": "^2.2.0",
     "@govtechsg/oa-encryption": "^1.3.2",
     "@govtechsg/oa-verify": "^7.3.3",
-    "@govtechsg/token-registry": "^2.5.0",
+    "@govtechsg/token-registry": "^2.5.1",
     "@govtechsg/open-attestation": "^5.1.0",
     "ajv": "^6.12.3",
     "chalk": "^4.1.0",


### PR DESCRIPTION
@govtechsg/token-registry: 2.5.1
This new version includes the updated interfaceID that is registered in the TradeTrustERC721.sol smart contract.