### PR TITLE
fix: error thrown by ajv when encountering a nested ref

### DIFF
--- a/src/__tests__/fixture/2.0/custom-schema-with-nested-ref.json
+++ b/src/__tests__/fixture/2.0/custom-schema-with-nested-ref.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://schemata.openattestation.com/sg/gov/moh/fhir/4.0.1/fhir-open-attestation-schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://schema.openattestation.com/2.0/schema.json"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "fhirVersion": {
+          "type": "string",
+          "examples": ["4.0.1"]
+        },
+        "fhirDocument": {
+          "$ref": "https://schemata.openattestation.com/sg/gov/moh/fhir/4.0.1/schema.json"
+        },
+        "validFrom": {
+          "type": "string",
+          "format": "date",
+          "description": "Date from which the document is considered valid"
+        },
+        "id": {
+          "type": "string",
+          "examples": ["TEST001"]
+        },
+        "name": {
+          "type": "string",
+          "examples": ["HealthCert"]
+        },
+        "logo": {
+          "type": "string",
+          "description": "base64 encoded image"
+        }
+      },
+      "required": ["fhirVersion", "fhirDocument", "validFrom", "id", "name"]
+    }
+  ]
+}

--- a/src/__tests__/fixture/2.0/custom-schema.json
+++ b/src/__tests__/fixture/2.0/custom-schema.json
@@ -1,0 +1,13 @@
+{
+  "$id": "https://schemata.openattestation.com/sg/gov/tech/geekout/1.0/geekout-open-attestation",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "https://schema.openattestation.com/2.0/schema.json"
+    },
+    {
+      "$ref": "https://schemata.openattestation.com/sg/gov/tech/geekout/1.0/schema.json"
+    }
+  ]
+}

--- a/src/__tests__/fixture/2.0/schema.json
+++ b/src/__tests__/fixture/2.0/schema.json
@@ -1,0 +1,249 @@
+{
+  "title": "Open Attestation Schema 2.0",
+  "$id": "https://schema.openattestation.com/2.0/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "identityProofDns": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["DNS-TXT"]
+        },
+        "location": {
+          "type": "string",
+          "description": "Url of the website referencing to document store"
+        }
+      },
+      "required": ["type", "location"]
+    },
+    "identityProofDid": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["DID"]
+        },
+        "key": {
+          "type": "string",
+          "description": "Public key associated"
+        }
+      },
+      "required": ["type", "key"]
+    },
+    "identityProofDnsDid": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["DNS-DID"]
+        },
+        "key": {
+          "type": "string",
+          "description": "Public key associated"
+        },
+        "location": {
+          "type": "string",
+          "description": "Url of the website referencing to document store"
+        }
+      },
+      "required": ["type", "key", "location"]
+    },
+    "identityProof": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/identityProofDns" },
+        { "$ref": "#/definitions/identityProofDnsDid" },
+        { "$ref": "#/definitions/identityProofDid" }
+      ]
+    },
+    "issuer": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Issuer's id, DID can be used"
+        },
+        "name": {
+          "type": "string",
+          "description": "Issuer's name"
+        },
+        "revocation": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["NONE", "REVOCATION_STORE"]
+            },
+            "location": {
+              "type": "string",
+              "description": "Smart contract address or url of certificate revocation list for Revocation Store type revocation"
+            }
+          }
+        },
+        "identityProof": { "$ref": "#/definitions/identityProof" }
+      },
+      "required": ["name", "identityProof"],
+      "additionalProperties": true
+    },
+    "documentStore": {
+      "allOf": [
+        { "$ref": "#/definitions/issuer" },
+        {
+          "type": "object",
+          "properties": {
+            "documentStore": {
+              "type": "string",
+              "pattern": "^0x[a-fA-F0-9]{40}$",
+              "description": "Smart contract address of document store"
+            }
+          },
+          "required": ["documentStore"]
+        }
+      ]
+    },
+    "certificateStore": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Issuer's name"
+        },
+        "certificateStore": {
+          "type": "string",
+          "pattern": "^0x[a-fA-F0-9]{40}$",
+          "deprecationMessage": "Use documentStore and identityProof instead of this",
+          "description": "Smart contract address of certificate store. Same as documentStore"
+        }
+      },
+      "required": ["name", "certificateStore"],
+      "additionalProperties": true
+    },
+    "tokenRegistry": {
+      "allOf": [
+        { "$ref": "#/definitions/issuer" },
+        {
+          "type": "object",
+          "properties": {
+            "tokenRegistry": {
+              "type": "string",
+              "pattern": "^0x[a-fA-F0-9]{40}$",
+              "description": "Smart contract address of token registry"
+            }
+          },
+          "required": ["tokenRegistry"]
+        }
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Internal reference, usually serial number, of this document"
+    },
+    "$template": {
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Template name to be use by template renderer to determine the template to use"
+            },
+            "type": {
+              "type": "string",
+              "description": "Type of renderer template",
+              "enum": ["EMBEDDED_RENDERER"]
+            },
+            "url": {
+              "type": "string",
+              "description": "URL of a decentralised renderer to render this document"
+            }
+          },
+          "required": ["name", "type"]
+        }
+      ]
+    },
+    "documentUrl": {
+      "type": "string",
+      "description": "URL of the stored document"
+    },
+    "issuers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "issuer",
+        "oneOf": [
+          {
+            "$ref": "#/definitions/tokenRegistry"
+          },
+          {
+            "$ref": "#/definitions/documentStore"
+          },
+          {
+            "$ref": "#/definitions/certificateStore"
+          },
+          {
+            "allOf": [
+              { "$ref": "#/definitions/issuer" },
+              {
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": ["certificateStore"]
+                    },
+                    {
+                      "required": ["tokenRegistry"]
+                    },
+                    {
+                      "required": ["documentStore"]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "minItems": 1
+    },
+    "recipient": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Recipient's name"
+        }
+      },
+      "additionalProperties": true
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "filename": {
+            "type": "string",
+            "description": "Name of attachment, with appropriate extensions"
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of attachment"
+          },
+          "data": {
+            "type": "string",
+            "description": "Base64 encoding of attachment"
+          }
+        },
+        "required": ["filename", "type", "data"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["issuers"],
+  "additionalProperties": true
+}

--- a/src/__tests__/fixture/2.0/valid-custom-schema-document.json
+++ b/src/__tests__/fixture/2.0/valid-custom-schema-document.json
@@ -1,0 +1,31 @@
+{
+  "recipient": {
+    "name": "Matthea Loo"
+  },
+  "programme": {
+    "name": "GeekOut 2020",
+    "startDate": "2020-10-12",
+    "endDate": "2020-10-14"
+  },
+  "signatory": {
+    "name": "Alice",
+    "position": "Boss",
+    "organisation": "ABC",
+    "signature": "signature"
+  },
+  "issuers": [
+    {
+      "name": "GovTech",
+      "documentStore": "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.openattestation.com"
+      }
+    }
+  ],
+  "$template": {
+    "name": "GEEK_OUT_2020",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://stoic-lumiere-531096.netlify.app"
+  }
+}

--- a/src/__tests__/fixture/2.0/valid-custom-schema-with-nested-ref-document.json
+++ b/src/__tests__/fixture/2.0/valid-custom-schema-with-nested-ref-document.json
@@ -1,0 +1,254 @@
+{
+  "id": "DOCUMENT_1234",
+  "name": "HEALTHCERTS",
+  "validFrom": "2020-11-20",
+  "fhirVersion": "4.0.1",
+  "fhirDocument": {
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+      {
+        "fullUrl": "urn:uuid:aaaa1321-4af5-424c-a0e1-ed3aab1c349d",
+        "resource": {
+          "resourceType": "Patient",
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/patient-nationality",
+              "extension": [
+                {
+                  "url": "code",
+                  "valueCodeableConcept": {
+                    "text": "SG"
+                  }
+                }
+              ]
+            }
+          ],
+          "identifier": [
+            {
+              "type": {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                    "code": "PPN"
+                  }
+                ]
+              },
+              "value": "E7831177G"
+            },
+            {
+              "type": {
+                "coding": [
+                  {
+                    "code": "NRIC"
+                  }
+                ]
+              },
+              "value": "S9098989Z"
+            }
+          ],
+          "name": [
+            {
+              "text": "Tan Chen Chen"
+            }
+          ],
+          "gender": "female",
+          "birthDate": "1990-01-15"
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:bbbb1321-4af5-424c-a0e1-ed3aab1c349d",
+        "resource": {
+          "resourceType": "Specimen",
+          "type": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "258500001",
+                "display": "Nasopharyngeal swab"
+              }
+            ]
+          },
+          "collection": {
+            "collectedDateTime": "2020-09-27T06:15:00Z"
+          }
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:99991321-4af5-424c-a0e1-ed3aab1c349d",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MOH",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "govt",
+                  "display": "Government"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:11111321-4af5-424c-a0e1-ed3aab1c349d",
+        "resource": {
+          "resourceType": "Practitioner",
+          "name": [
+            {
+              "text": "Dr Michael Lim"
+            }
+          ],
+          "qualification": [
+            {
+              "identifier": [
+                {
+                  "system": "http://example.org/UniversityIdentifier",
+                  "value": "MCR 123214"
+                }
+              ],
+              "code": {
+                "coding": [
+                  {
+                    "system": "https://www.hl7.org/fhir/v2/0360/2.7/index.html",
+                    "code": "BS",
+                    "display": "Bachelor of Science"
+                  }
+                ],
+                "text": "Bachelor of Science"
+              },
+              "issuer": {
+                "reference": "urn:uuid:99991321-4af5-424c-a0e1-ed3aab1c349d"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:cccc1321-4af5-424c-a0e1-ed3aab1c349d",
+        "resource": {
+          "resourceType": "Observation",
+          "identifier": [
+            {
+              "value": "123456789",
+              "type": "ACSN"
+            }
+          ],
+          "code": {
+            "coding": [
+              {
+                "system": "http://loinc.org",
+                "code": "94531-1",
+                "display": "Reverse transcription polymerase chain reaction (rRT-PCR) test"
+              }
+            ]
+          },
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "260385009",
+                "display": "Negative"
+              }
+            ]
+          },
+          "effectiveDateTime": "2020-09-28T06:15:00Z",
+          "status": "final",
+          "performer": [
+            {
+              "reference": "urn:uuid:11111321-4af5-424c-a0e1-ed3aab1c349d"
+            },
+            {
+              "reference": "urn:uuid:dddd1321-4af5-424c-a0e1-ed3aab1c349d"
+            },
+            {
+              "reference": "urn:uuid:eeee1321-4af5-424c-a0e1-ed3aab1c349d"
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:dddd1321-4af5-424c-a0e1-ed3aab1c349d",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Medical Clinic",
+          "type": [
+            {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/organization-type",
+                  "code": "prov",
+                  "display": "Healthcare Provider"
+                }
+              ]
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                {
+                  "system": "phone",
+                  "value": "+6563113111"
+                }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "MacRitchie Hospital Thomson Road Singapore 123000"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "fullUrl": "urn:uuid:eeee1321-4af5-424c-a0e1-ed3aab1c349d",
+        "resource": {
+          "resourceType": "Organization",
+          "name": "MacRitchie Laboratory",
+          "type": [
+            {
+              "coding": [
+                {
+                  "display": "Accredited Laboratory"
+                }
+              ]
+            }
+          ],
+          "contact": [
+            {
+              "telecom": [
+                {
+                  "system": "phone",
+                  "value": "+6562711188"
+                }
+              ],
+              "address": {
+                "type": "physical",
+                "use": "work",
+                "text": "2 Thomson Avenue 4 Singapore 098888"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "issuers": [
+    {
+      "name": "GovTech",
+      "documentStore": "0x8Fc57204c35fb9317D91285eF52D6b892EC08cD3",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.openattestation.com"
+      }
+    }
+  ],
+  "$template": {
+    "name": "HEALTH_CERT",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://healthcert.renderer.moh.gov.sg/"
+  },
+  "logo": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAlgAAAA9CAMAAABGHucuAAABaFBMVEX///9YWVsAgGbR09RssaT9/f1aW127vcCKjI/x8vJaqpoAgmn5+fmAgYT19fViY2VdXmAAhWz8/f1sbnBkZWjf4OGUlpmRk5YAh29naGqnqayHiYyEhoh8foEAkXxfYGOanJ95e32dn6J2eHv1+vmXmZwvnYkAjHXx9/bj5OXJy82xs7aho6bd3t+3ubxpa22WxryusLKqra90dXjNztCOkJPAwcTo8vBvcXOeysCkpqn5/Pvq6+zc7OfQ0dPFxsh8uawAlH/39/fCxMa0trgCloLa3N201c7GyMpTqJcAinLr7Ozl5ufW19mq0Mhxc3XP5N9hrZ8Ajnjt7e7U5+KQw7iGvrJxtKaBvK9MpZQQmIXY2dvU1delzsVosKLj7+zn6OnH4NrV19g4n43L4tzA3Na82tKKwLUamobs9fPu7/C42NE+oY/7+/vX6eSw08uwsrRHpJIlm4h2tqm6vL5DopHU1tfR5uBe1I8GAAAWUklEQVR42uzY61PTQBQF8HOvTQUiYqtgFYnVVqkvKIoPUBAFxaLTAZFSqqjIQxgqjI/Rf9+hu+3ukhbTJjoZp7+P3WnyIWfOvQn+nczqQmnOZuZEaXkCmvja2FSka2H582wabW1NsVbXbVbsiAUhs/Qtpn7eHoujrc0rKzvIh0RwYCeSYNPrWbT9V6YiRyqOzcfRojWHXewJANkEu02h7T+yx38UK+cttOC7zXUsIf2V6yqizZOToyNXLnSnUt0dyaHnFsKpwF44W2hWpixj+bWYLZS5pvDhiewup5zLlbTw2Rvwo7ND9wqGd/rZZfgx3Sd9QcVkjzSJwJzvEM7DZXFmIEqac8lehNFV9qbQbK6ecUX5Pg5sDrK0+1rsVEsZHJjY5pp1+DFJurcwXCBNH/zoJ+EBhNskdSIwwyTcxCHX+k6Ry9lFhM9+IbJSYt3V/Nbm7v5+PtuVMEdYM9LymisWhL05rsiJvasrDSntqMrKwIfbpDsGXS/pZuDHuerjdAUtMI9ImoahMxmles69Qzh9Zs2+ap0cK/Y8miD/OZhG1WasktpvIm96tLlmFz50HBGsK642a9lHkm4cCtpdBOYFSeZAHx2mBk6NIpTmWTFqo8xKuYWkZvUAJThRXOYDcxko1hxXjcGH4cbB6rxoPIUT8GGapJ+uoAVmnIQz0Fjj1FhPOBetNVaeQPNB363vw6u9mCysODTpifgsVxQbrHl5tO4lGa5DM0K6S/DjJgnRp6h4rIIWELUR9kN52k9HuRTKL8xZVt5Dt87cQp+U1LUMO3KFNyO6wlXzaN11MryAEj9NuiT86CYh5Q5aUKweEs5rueom3cUHqdNR0v1ACC2wsgpdkZUIPMqztAFTl16K7mDZ6QDGR9QdrGkyHIcPVnWqXoHQ3yMMIDDX3LV74gIpA0PXAODLp8vaiL+DEHrGyg50s6zk4E3cYWEQpq36Reaw5AQxPu6436cG5IHUCx96SRrCX3OPpEVU9VFN6pg2/7Uee47Qice4xmm8fa3Am1WWFmB46NSdqQ9tdYPWWWdIOOuqpbeiyeQBXbTgw3GSbuGvSZJwGlUzVDNuQXNCJWsEoaPS4wrDG+PIm+0GXw+mWPoF3QZXFYMYH79pt/a3JIIoOgPuCsYbVB4SEpJI+UoySxA1tTTN0nx8Si/N8lHmq69/v2R35s69u+OH31fnJxGEHebsufecO545iGUxyickLcgcCFXXQ7fc9Nx/bJazNMAYlKmoWWcYyyaHXK1VxJYbU2XvYIj9Z2ygFkvLuelbZhdJLA0fhS5GDY1zOPkX5aNBiVU1rfwh7JpmB8q9+VzT2gfT7iI0mO4ZNrm52tVMIfOizxGl0WthhZrUq+5CgvNIauzxXJU5Ub0qZodNznOpYHEcZ/Y/IkSDjLzkVVkf3/UwG3teC0030bheXoEBjKnegiBjvKtC5LvhtdDJAANeGyK8sR8248BAvVhIhROFYtnQpZlg2HCPddt939L0ZB0QaCC8/Se9+z0RQvtFuo67+oJsjuoMcPwwwRUEF5xZZZ5L+Pyw6WLeWHDVwakersJH2jqjjj2e6VM/eIFmcUNc4Iw5MMfJFYRMsKkredtoCMyOkpB1rOKa2dy7YYZ1BWFI4CzFBSacpJ9BLZZuRp2cZC3hrns88UVnAuaBcASl2rua5kOP3p0euZaPjJ/ElbMWda6uuI1PsL+jYY5hPiIxOyZIIbQrfhy339100cGBHk5gjiINzHMHugKMER6ZIZspCSRKBGX6pBfykDOTGI26S3afpm9GvQ8dLRTlHw6ucgFo/wB9SgrawTC+u7ZYsYORtsVf9/fPP2y80af4m+9UXEBJfdKEgZwD7eEO2naSFtW3agyjNn3RfCo6//an4F0sIlZLiWURKjHbJSQNWyoKxICpBB33Sn0YYE2suOxEe47fuH3jEe6CbocDHKND0MgycyLmtxEiaXCRPSSGMSAoob20Z2h5dLRARLpSpgt9xhAO9CFoCfxi9KNYyfv9qAfQP11C3f6+p0WUQMnoZ5c219Qh09ak+gHoNFey4xSXj4qfEGTMXvIYTbMHU9wF5q6Sf5mcIk+GLQ9gqoc3h8IcBF9JQJP7MXwII5CA+tQKHos85EwSMmYpXw93h9eR2ST0MywQ6XaTU1RwuUMtli4f/SbChDUPQf9XZuPJZb+nVUQdzkEw1xhZ8mBclOBi6enBb7gNOfbj23DK2taq6Dy4KHYLCU5Am6WyybXoAcdJduIhJyCFpEHfldJGXukQsSXmK9YKxJgBCJ4lyQRFQZawBCxPO8PaE49dhHfVQMm3tsWqgTSd21oiX5xcklt8x2bW06indazRnr5fuEcomo6TWkaH/drzfUG+A1T348zAxMrYu9ogN1V1mAPQV7Qn/B4Seo3oT1AdnOMUOJ+YneASqfiwC1e9pIAFb5cnrEseYsoajzlZMaBCM5u0ZoYFIq1BBXXbuhbrCJ65P4mO73kW3zDWtyGo1V8CB9kqdqhz+GUXZsGYmemRbfnkBnKcmwZjsadWD9ZnlQ/QBfTVDAiynOHjeEZWfsX3VgIsVM7SUWJgVSmAxUfpjOky4/bTnVgxgShDU432DOc4UU1LE9V+fM2zcgF0BfdIkR+YKLzS6syUYhwP4sP3vCEW6EznHGr6HJann2F1c4CZ7U335jVz2JKuxfqyBoSbFL082udFVI9O2v5iTWmN2gAfoIIdWr8Zobn7pnW4xn4cfd9c1S+hjyVlJnTJmjhNSuELmdB7o8LSaxEDOo8Jct5hdYAxfEOv0pKWXbCa2CwH2FWpAjtB2BhvUAUrI4eXDQkLYSLFgivNkqwhYbBWkMZpQqbbF1y+rvyS8Zl1IckpSTUDMhtYnmaGpUhuV9UabcCv8pqo6rXSJHfILU8+JVnmBe2P7rsch5hnKvqhldI4h8/AK6iuNaAdnJqoiQ5Q6BwUOi8mVign0tIJdHNWc2L/12X6Lr/mAEm0DfEK0LBhatjWCV/jVUY8FG9XaRKugpsnN3scP/a5VkJvO0Un1H6B+NCx1B15GUXgZ50LdOLMJn7DDMsPcvVcki8i2Y8mLYDk9NfTJ7U3L0Y6lAPDHaKjn+wnwvYN+iNCIDpq7vMILGkOr0Zj11lF1CNEycaa0v39tn9+wSycynHAmYx+gFjQD6QC7Bh75l7sAdHv+DIS/KDbRvhE7I13wh8WZawTTCIiVtARex2TXn0dJ2VGAv5eAZQfWr0SoCezTAB0r8dQqlwcQmNU9XwM0IutJavgCkvLI4mq9Ih+gBjpNf13mjYHsY6I+jmFaV9zZubwuioLGvVPwtEuGzXwqIcGsO7ELh8Q/eTgfjfiogGqIM+8HnFpCebUW/OT2O5EVZm15DixlsO4SXnkEugMoZ0vv7Tgh40jilDGUdIgB74DAmIBjuK8DLwylNfHXaOwblzmBuny8AyLrLHL9WASKlJ6HD7to6OfpcX3JZForaFOnNTVI/dx5KUmp99SHeI2cxBrRCFhR8y2oXfuGnbdh8WGYdl1adPTyDOPikdV5sKAAVVnRnG8b2OK/NPDKFaAsF/pUR7YqDInjL0Mdo1wpWEDV6IwU7DCKYbpFsdn6STVOShNYx2/guUBJU2ShmQERV+5HSYymcQTzw0YwSS4M3/5GU/5aGi+rUku3lIhA+cA9e3EpQ+7qxjWC7CUNfvimxyHQjeEiRWUcpJBnnlMPPIqKMoojDFDSFFKbA/uX0L2IBFHjJVbnFH179ZHe4NKlpYln9FDPEQQDwgpfCh1opUzCHeSikeYWEW0PELhcdISFtFqgN9KfQPMzP+FGkad44l0CZnGCxcCnmuSix1NBPtCmUAbMy6kTCr+YEep0NsxJgE7ugvEAmlfoV/HAL8JERECwn1KibVKT62G8MbsMQwqU3/au9aupIIoeg0vj+QlkKICiqKFCigpqCiEpeaT1MxMzceytPcql/X3i+By5uyZaa2yD7Vkf0Ov98LM9jz2OWfIRjKyPgox0gxwuQN8GCALFPK5VeNkPZoMMse8XkVF4STcalFJrChrRrAQxh/cak/oOno22KTrGcbaWBwKYzSGmUOZUby9AdEC7rHh7BO2QCT9+Br/wR2Nz3pMJk0v8VGchlU2jDc6sWuVR1xdpqHH6gwnFRQb16BpP45hG7l+hiJTnSCHTGNjPPal2sjrwd9iaaGknKJcU9B/CPRtmswheiBe81nWW20FSv4o2BZwBM+Q1YlNMkgAyibH+EMfmGhJomSrnY0QPSfmcymWwWtrL3G1duTjE6+mjy1nku6ghTmu0/PXIEaahaG2cTAQAC8EOzkwcPQQVcz4lrweDPRWQGUbVXr7YcUM3Arr5MP2rC+KRr6XUrhfxq52tEyf4Bly5nBIx5NoiVWAB18lVFJQ0CJWt6U10HL0BuhyHcYFvbVHPau6DhWQNI+zR/SRVQQLPVNgEUYhWPGpiGW6LIyQ9+Lv4ZgZOOjswNwyyL2e0LToRYPpUc5od8uzwHO3CK8ajS+Ej+ACxxYsb/X5XO6weqaJzp4LMbrakuWNS7JFQwrsET+JWbDhOSJWj+HuomKLRzRp2y0IdCqnkETBrtndkGvtc93aZmgwH2VPCk46vBGwCB4Ixn2ws4D74L36iJeEeUoAGGzcgXWyj4elBTDSSZyJw4btaSGwsRzaF92Yoblj2YzYWEIwT8/keva5ZnTwjXruIiZ6wrJ+whpbG7j7uEPE8tRp4N8WI49+dnpI1qGCl/JuGMWZhLpFP6/qRZikBICY2+cct7nEWL0bYqQsGGO1f82h94qrTG0SxXvMIB8yrxdXmaJV7mrtJit821FZZSOFF6oiT1gI30/Kllua1jSrxzSzp2XqaWBoFWxeO5BZiVrdG97dKEk/ArEGaC155JFTZNX6bIng8kOmHeWp0JRy0VXJqy/txj2fgBhpgkwSuSuEqwu8l5uagwQcqHPcD9Zf93rJ64GQEAcL6FBZRKrwO5QjhbsgHuEpM2NtFgNrksFL6tmTYvcwd6Bt5LwYLkivmINHarDE04Zp0RB7hP31HFBaR5FHkiWF+gZ6JbGysHwB0O99Cimz2F/HtlA2DJEfGaHwmcdILspLtCP8prMFvNc68BJcXh+YO+YJTxWN9UmUyfogWgNd3wVDfSBdsvQrJsVJCwng5BbG7pj8PdFNeIUplHsFb0SHj2WRWJui+xgVqr5xp2BM+liEnKVqswYdqtrGdi+UbBeBfn5Qn0XOB03D2FfQ1QPZ+yC9xn5Uj4m86pOaCh4BL8FiRYAOrJiUVpxOMIgLEWdMRoPViTU8DH8KK3LHwyc6RRRb5d9j7I7J3zQ4TXlSjEgJI2gyEstwBA7N3wjE6rIL0UOULWxWIVKZVhHvlIjIQxUz0gITr2kgWi9L6rkV6BY8duiDrGtPolKmaK8ahZyuQ26D6gRegn8NBVQRlhNeF2leyA4/c/tZgoIdkYvKtuQtplti6BW4iyngISv/QYz+GkIpcJpoGYdogpFYqcUlIxam2ANiBS3ABvVmeElsVFM1o1f+t8I+YG41CN1MGUkHcg+IxcO4ZDfMKLgftx0VC3evQB/RTKQGFMdRVICndFe0lbRq/qRUka5jlQ5TcdFQOYbp2xWVrn+lLt+8Ees6JzygPyRlFS1MDBVTlEFjmlHDS9ZvuIBjOS8ShvGstTVPf2dhE/w+ECvLl2OYewZ/Sgp1Ml5erHfWSTM/KFuO+6gUNG5Sp+OHSSZC+XFPTLqpDSzYuvLMuPuPLXe431kjC7eZXgyTMAPoSlqPztqx+dXZeMp8/RnEqwq6WqL+YuMquzA9WQhr7MRLPLNhF/I9sjCUASZ01ODWjhATqbmlC7KWVqrhfFgoHCXCdCWk2EQsMjhpnjN7qS3N8dOipUiKL+FZW9Fhl+FOjgfl4osXRwr7iQBVngQmoo2bmKJc3uWt2xxPC1qER3IIk2QMynRm0yMzTpJ4mXMuQqAvW9tQuvpwb44WKRpAYrXES0lX8qFTMZvW0ULoGX4bmJ0QCD4Dvki5m3NtcDT7MtDIFNLJo6MziN2XNS0MO5ru0TMufIRfCcbz9o/XSz/vcS6ZwLsBOcUWtquDL0dQPlQyFOlwTsmVYCZk+tXFl69ERktNIIQGKr30Yo3XYTzrpnmc6xGlUoiR4pCi6mDnzjlLRXHtEaz24EDGLjB1lUQ2PR6R6dMi7haC5zAQi7AHIulLrkoUlsXft9Uasnb5NUhf1N0TMSIWnldptRd+rH6FRfljzUDevYciySGk2ECsFF8OJ4bUiE6TMnEtQpgLzVruJaPZfVvt134khNz0UgEpCTqiEVPj3GY6YdQV5wVl+FLKYw/xba6Tq9UhIxSR3q2wXtFn93AiniYZRNu2N720U8ZqIfUVSz0z78JKwuVfgL6/zI+Wv7q9+XmrSrLWgpUqLOR5ltkKKTYQywM+axzjFplX1CKOCHVCiDopSTojal4NUwwG8HdxS+lSNlPd8bWoEV3N8cJdhnjJkbJr/knWmVkD2EfBMxdpbpcA0du9p4fSzHL70AM6YegLP+Q9T6xRIPbk6cmucEV4qdHv8OlKvHDhvP6E/DPG6t03dJAkUPZEyFPDz/M/rtttI16xFBv2rwT6YBHOxwN0m8JO+HELUj3WZThSCEkeIFSklnlAcD/O5YIJ9dlw68QsOO7BwSrOq+pKlJ7zFfacHqR97pHFIzBqmUUk6v1jUAAQG9CCR6HMJez3gqgm3ZNvtzVHSYCIIZ7XkfMzjG8rck/DTgDnWrfaaHaIpdhIrKAJNt7LNCDAFC8dl+x84daMLhwplEXUbTkGiRwT7yaBGC4jaLFvkcVIeDbcnQHF2e4PaVgENa9F5Sn4CHsfD8Vmg/wjpxrB6SC4WifebpDuhIPycmNfjLcoF4bE654XjraoMUrF0/YAdZSCVg4/J284V2crDQ0loPgjzw65MMXuEXJ8nLQgDE9x4/EIZXibsMz+mXljDSa9JlTVEy8Q9v5DogjQOXogBsP9bOM8BsCN5+KEul1Elx5S6akojihWgFaTKQMwGxEeMPKB3p4DJtOyhtltp2s9p6JmqcSOJmNcyRtGYbPx6rK6qfkhwVcd3kY8qN2kFfGu9nPp+p9xfeB8RXCbYwmmWLSHyV4+P2rspa2Ot3AUms1rKS3113whAyWntVmVwQnTkOAdGajtQLx7VThu7MDaBesx89y49DcYG+womshWp7/2q77aXqSsm9QnP+nYM8S8o6e3YawmH9YfumarIqk8BA4ReDwZasTsEToNTsT+qCfj6w3GB0tu8Rg2F7jaYvVhg8Ha6oymjN8BtNVdJKrReevC3diX1iXTispvX7xY3jCNv4nCxmZ5pX2lvLfDB1uv7j5PmJ9uXyxcvN+cnjP+Csy14uPHE784MdG7+GOT3cZvYvu05HCUDrbV25tcty26jD9BIDnhSDtKxdU//8DHxepbs6392Z4NQ5rkSt6ZNa/7xWDlOaOJG44Z0uGvhUKMxUy7R0YTNxoR0uGvh7N27Nds4iYjRDr8NfE63Pxy3SYsJEmHvzaO9prEaqKOHOjw18PT3VibpSqNGU3cYPSDDn9tJM42pqc3XuWNJm40oo36UxNN/A3A7IjDaKKJvwY6Pevf/DLXJv5XpKFCrsZ3fTXH9LHs2cUAAAAASUVORK5CYII="
+}

--- a/src/__tests__/wrap.v2.e2e.test.ts
+++ b/src/__tests__/wrap.v2.e2e.test.ts
@@ -1,0 +1,56 @@
+import { handler } from "../commands/wrap";
+import path from "path";
+import tmp from "tmp";
+import signale from "signale";
+
+const fixtureFolderName = path.join("fixture", "2.0");
+const validFileName = "example.0.json";
+const exampleFolderPath = path.resolve("examples", "v2", "raw-documents", validFileName)
+const validFileNameWithCustomSchemaWithNestedRef = "valid-custom-schema-with-nested-ref-document.json";
+const validFileNameWithCustomSchema = "valid-custom-schema-document.json";
+
+describe("wrap with file input", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  const signaleSuccessSpy = jest.spyOn(signale, "success");
+  describe("without custom schema", () => {
+    it("should allow output when given valid open attestation document", async () => {
+      const outputFile = tmp.fileSync();
+      await handler({
+        rawDocumentsPath: exampleFolderPath,
+        outputFile: outputFile.name,
+        openAttestationV3: false,
+        unwrap: false,
+        batched: true,
+      });
+      expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+  describe("with custom schema", () => {
+    it("should allow output as file if input path is an input file with custom schema", async () => {
+      const outputFile = tmp.fileSync();
+      await handler({
+        rawDocumentsPath: path.resolve(__dirname, fixtureFolderName, validFileNameWithCustomSchema),
+        outputFile: outputFile.name,
+        schema: path.resolve(__dirname, fixtureFolderName, "custom-schema.json"),
+        openAttestationV3: false,
+        unwrap: false,
+        batched: true,
+      });
+      expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);;
+    });
+    it("should allow output as file if input path is an input file with custom schema that has a reference to an external schema", async () => {
+      const outputFile = tmp.fileSync();
+      await handler({
+        rawDocumentsPath: path.resolve(__dirname, fixtureFolderName, validFileNameWithCustomSchemaWithNestedRef),
+        outputFile: outputFile.name,
+        schema: path.resolve(__dirname, fixtureFolderName, "custom-schema-with-nested-ref.json"),
+        openAttestationV3: false,
+        unwrap: false,
+        batched: true,
+      });
+      expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);;
+    });
+  });
+});

--- a/src/__tests__/wrap.v2.e2e.test.ts
+++ b/src/__tests__/wrap.v2.e2e.test.ts
@@ -5,7 +5,7 @@ import signale from "signale";
 
 const fixtureFolderName = path.join("fixture", "2.0");
 const validFileName = "example.0.json";
-const exampleFolderPath = path.resolve("examples", "v2", "raw-documents", validFileName)
+const exampleFolderPath = path.resolve("examples", "v2", "raw-documents", validFileName);
 const validFileNameWithCustomSchemaWithNestedRef = "valid-custom-schema-with-nested-ref-document.json";
 const validFileNameWithCustomSchema = "valid-custom-schema-document.json";
 
@@ -38,7 +38,7 @@ describe("wrap with file input", () => {
         unwrap: false,
         batched: true,
       });
-      expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);;
+      expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);
     });
     it("should allow output as file if input path is an input file with custom schema that has a reference to an external schema", async () => {
       const outputFile = tmp.fileSync();
@@ -50,7 +50,7 @@ describe("wrap with file input", () => {
         unwrap: false,
         batched: true,
       });
-      expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);;
+      expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/__tests__/wrap.v2.e2e.test.ts
+++ b/src/__tests__/wrap.v2.e2e.test.ts
@@ -1,4 +1,5 @@
 import { handler } from "../commands/wrap";
+import fs from "fs";
 import path from "path";
 import tmp from "tmp";
 import signale from "signale";
@@ -24,6 +25,13 @@ describe("wrap with file input", () => {
         unwrap: false,
         batched: true,
       });
+      const file = JSON.parse(
+        fs.readFileSync(path.resolve(outputFile.name), {
+          encoding: "utf8",
+        })
+      );
+      expect(file.signature.merkleRoot).toBeTruthy();
+      expect(file.signature.targetHash).toBeTruthy();
       expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);
     });
   });
@@ -38,6 +46,13 @@ describe("wrap with file input", () => {
         unwrap: false,
         batched: true,
       });
+      const file = JSON.parse(
+        fs.readFileSync(path.resolve(outputFile.name), {
+          encoding: "utf8",
+        })
+      );
+      expect(file.signature.merkleRoot).toBeTruthy();
+      expect(file.signature.targetHash).toBeTruthy();
       expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);
     });
     it("should allow output as file if input path is an input file with custom schema that has a reference to an external schema", async () => {
@@ -50,6 +65,13 @@ describe("wrap with file input", () => {
         unwrap: false,
         batched: true,
       });
+      const file = JSON.parse(
+        fs.readFileSync(path.resolve(outputFile.name), {
+          encoding: "utf8",
+        })
+      );
+      expect(file.signature.merkleRoot).toBeTruthy();
+      expect(file.signature.targetHash).toBeTruthy();
       expect(signaleSuccessSpy).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/implementations/wrap/wrap.ts
+++ b/src/implementations/wrap/wrap.ts
@@ -242,10 +242,10 @@ const loadSchema = (schemaPath?: string): Promise<Schema | undefined> => {
   return Promise.resolve(undefined);
 };
 
-const remoteLoadSchema = async (uri: string) => {
-  const response = await fetch(uri)
-  return response.body
-}
+const remoteLoadSchema = async (uri: string): Promise<boolean | NodeJS.ReadableStream> => {
+  const response = await fetch(uri);
+  return response.body;
+};
 
 interface WrapArguments {
   inputPath: string;

--- a/src/implementations/wrap/wrap.ts
+++ b/src/implementations/wrap/wrap.ts
@@ -45,7 +45,7 @@ export const wrapIndividualDocuments = async (
   const documentFileNames = await documentsInDirectory(undigestedDocumentPath);
   let compile: Ajv.ValidateFunction | undefined;
   if (schema) {
-    compile = new Ajv().compile(schema);
+    compile = await new Ajv({ loadSchema: remoteLoadSchema }).compileAsync(schema);
   }
 
   for (const file of documentFileNames) {
@@ -241,6 +241,11 @@ const loadSchema = (schemaPath?: string): Promise<Schema | undefined> => {
   }
   return Promise.resolve(undefined);
 };
+
+const remoteLoadSchema = async (uri: string) => {
+  const response = await fetch(uri)
+  return response.body
+}
 
 interface WrapArguments {
   inputPath: string;


### PR DESCRIPTION
- add in async functionality for loading schema for ajv validator
- add in e2e tests for wrapping for various different schemas

context: https://github.com/Open-Attestation/open-attestation-cli/issues/122
this pr does the following:
- converts the existing ajv.compile into an async one
- adds additional v2 schemas to cover the cases whereby a custom schema has a nested ref.

please tell me if im duplicating code for e2e testing here, i took a look around, doesnt seem to have an e2e wrap test for v2 documents.
also is this a good decision in the first place to convert the sync compile into an async one?
i was thinking of looking up a definitive key for a nested ref in a custom schema to state that its a schema with a nested ref, then only do the async compile but i feel like it might be quite expensive to do so.