### PR TITLE
Feat : add cancel transaction command

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,12 +388,29 @@ You will need:
 ## Cancel pending transaction
 This command will cancel pending transaction.
 
-Please note that a this action is irreversible
+Please note that a this action is irreversible.
+
+You will need:
+
+- `--nonce` option specify which transaction to cancel.
+- `--gas-price` option, the gas price is required to be higher than the pending transaction.
+- `--transaction-hash` transaction hash option can be used as an alternative to nonce and gas-price option.
+- options to provide the wallet (https://github.com/Open-Attestation/open-attestation-cli#providing-the-wallet)
+
 
 ```
-open-attestation transaction cancel --nonce <PENDING TRANSACTION NONCE> --gas <GAS FEE> [options]
+open-attestation transaction cancel --nonce <pending transaction nonce> --gas-price <gas price> [option]
 ```
 
+Examples:
+
+```
+open-attestation transaction cancel --nonce 1 --gas-price 300 --network ropsten --encrypted-wallet-path /path/to/wallet
+```
+
+```
+open-attestation transaction cancel --transaction-hash 0x000 --network ropsten --encrypted-wallet-path /path/to/wallet
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ You will need:
 
 - `--nonce` option specify which transaction to cancel.
 - `--gas-price` option, the gas price is required to be higher than the pending transaction.
-- `--transaction-hash` transaction hash option can be used as an alternative to nonce and gas-price option.
+- `--transaction-hash` transaction hash option can be used as an alternative to nonce and gas-price option. Using this option will automatically increase the transaction gas price by 100%.
 - options to provide the wallet (https://github.com/Open-Attestation/open-attestation-cli#providing-the-wallet)
 
 

--- a/README.md
+++ b/README.md
@@ -385,6 +385,18 @@ You will need:
 - `--config-template-path` option to provide a path to a config file.
 - `--config-type` option specify which default template to use to create the config file.
 
+## Cancel pending transaction
+This command will cancel pending transaction.
+
+Please note that a this action is irreversible
+
+```
+open-attestation transaction cancel --nonce <PENDING TRANSACTION NONCE> --gas <GAS FEE> [options]
+```
+
+
+
+
 ## Help
 
 Run the command with `--help` to get additional information

--- a/src/commands/transaction.ts
+++ b/src/commands/transaction.ts
@@ -1,0 +1,9 @@
+import { Argv } from "yargs";
+
+export const command = "transaction <method>";
+
+export const describe = "Invoke a function over a transaction on the blockchain ";
+
+export const builder = (yargs: Argv): Argv => yargs.commandDir("transaction", { extensions: ["ts", "js"] });
+
+export const handler = (): void => {};

--- a/src/commands/transaction/cancel.ts
+++ b/src/commands/transaction/cancel.ts
@@ -1,11 +1,9 @@
 import { Argv } from "yargs";
-import { error, info, success } from "signale";
+import { error, info } from "signale";
 import { getLogger } from "../../logger";
-import { readFile } from "../../implementations/utils/disk";
-// import { issueToTokenRegistry } from "../../implementations/token-registry/issue";
+import { cancelTransaction } from "../../implementations/transaction/transaction";
 import { TransactionCancelCommand } from "./transaction-command.type";
 import { withNetworkAndKeyOption } from "../shared";
-// import { getEtherscanAddress } from "../../utils";
 
 const { trace } = getLogger("transaction:cancel");
 
@@ -29,26 +27,16 @@ export const builder = (yargs: Argv): Argv =>
   );
 
 export const handler = async (args: TransactionCancelCommand): Promise<void> => {
-  //   console.log(`Args: ${JSON.stringify(args, null, 2)}`);
   trace(`Args: ${JSON.stringify(args, null, 2)}`);
   try {
     if (!args.encryptedWalletPath) {
       error(`Wallet file not provided, please provide your wallet path`);
       return;
     }
-    const wallet = await readFile(args.encryptedWalletPath);
-    const walletObject = JSON.parse(wallet);
     info(`Wallet detected at ${args.encryptedWalletPath}`);
-    walletObject.address;
-    // info(`Cancelling pending transaction in ${args.encryptedWalletPath} to the initial recipient ${args.to} in the registry ${args.address}`);
-    // const { transactionHash } = await issueToTokenRegistry({
-    //   ...args,
-    // });
-    // success(
-    //   `Token with hash ${args.tokenId} has been issued on ${args.address} with the initial recipient being ${args.to}`
-    // );
-    // info(`Find more details at ${getEtherscanAddress({ network: args.network })}/tx/${transactionHash}`);
-    // return args.address;
+    await cancelTransaction({
+      ...args,
+    });
   } catch (e) {
     error(e.message);
   }

--- a/src/commands/transaction/cancel.ts
+++ b/src/commands/transaction/cancel.ts
@@ -18,11 +18,13 @@ export const builder = (yargs: Argv): Argv =>
         description: "Pending transaction nonce",
         type: "string",
         implies: "gas-price",
+        conflicts: "transaction-hash",
       })
       .option("gas-price", {
         description: "Require higher gas fee than the pending transaction",
         type: "string",
         implies: "nonce",
+        conflicts: "transaction-hash",
       })
       .option("transaction-hash", {
         alias: "th",

--- a/src/commands/transaction/cancel.ts
+++ b/src/commands/transaction/cancel.ts
@@ -17,22 +17,23 @@ export const builder = (yargs: Argv): Argv =>
       .option("nonce", {
         description: "Pending transaction nonce",
         type: "string",
-        demandOption: true,
+        implies: "gas-price",
       })
-      .option("gas", {
+      .option("gas-price", {
         description: "Require higher gas fee than the pending transaction",
         type: "string",
-        demandOption: true,
+        implies: "nonce",
+      })
+      .option("transaction-hash", {
+        alias: "th",
+        description: "Pending transaction hash",
+        type: "string",
       })
   );
 
 export const handler = async (args: TransactionCancelCommand): Promise<void> => {
   trace(`Args: ${JSON.stringify(args, null, 2)}`);
   try {
-    if (!args.encryptedWalletPath) {
-      error(`Wallet file not provided, please provide your wallet path`);
-      return;
-    }
     info(`Wallet detected at ${args.encryptedWalletPath}`);
     await cancelTransaction({
       ...args,

--- a/src/commands/transaction/cancel.ts
+++ b/src/commands/transaction/cancel.ts
@@ -1,0 +1,55 @@
+import { Argv } from "yargs";
+import { error, info, success } from "signale";
+import { getLogger } from "../../logger";
+import { readFile } from "../../implementations/utils/disk";
+// import { issueToTokenRegistry } from "../../implementations/token-registry/issue";
+import { TransactionCancelCommand } from "./transaction-command.type";
+import { withNetworkAndKeyOption } from "../shared";
+// import { getEtherscanAddress } from "../../utils";
+
+const { trace } = getLogger("transaction:cancel");
+
+export const command = "cancel [options]";
+
+export const describe = "Cancel pending transaction on the blockchain";
+
+export const builder = (yargs: Argv): Argv =>
+  withNetworkAndKeyOption(
+    yargs
+      .option("nonce", {
+        description: "Pending transaction nonce",
+        type: "string",
+        demandOption: true,
+      })
+      .option("gas", {
+        description: "Require higher gas fee than the pending transaction",
+        type: "string",
+        demandOption: true,
+      })
+  );
+
+export const handler = async (args: TransactionCancelCommand): Promise<void> => {
+  //   console.log(`Args: ${JSON.stringify(args, null, 2)}`);
+  trace(`Args: ${JSON.stringify(args, null, 2)}`);
+  try {
+    if (!args.encryptedWalletPath) {
+      error(`Wallet file not provided, please provide your wallet path`);
+      return;
+    }
+    const wallet = await readFile(args.encryptedWalletPath);
+    const walletObject = JSON.parse(wallet);
+    info(`Wallet detected at ${args.encryptedWalletPath}`);
+    walletObject.address;
+    // info(`Cancelling pending transaction in ${args.encryptedWalletPath} to the initial recipient ${args.to} in the registry ${args.address}`);
+    // const { transactionHash } = await issueToTokenRegistry({
+    //   ...args,
+    // });
+    // success(
+    //   `Token with hash ${args.tokenId} has been issued on ${args.address} with the initial recipient being ${args.to}`
+    // );
+    // info(`Find more details at ${getEtherscanAddress({ network: args.network })}/tx/${transactionHash}`);
+    // return args.address;
+  } catch (e) {
+    error(e.message);
+  }
+};

--- a/src/commands/transaction/transaction-command.type.ts
+++ b/src/commands/transaction/transaction-command.type.ts
@@ -1,6 +1,7 @@
 import { NetworkAndKeyOption } from "../shared";
 
 export interface TransactionCancelCommand extends NetworkAndKeyOption {
-  nonce: string;
-  gas: string;
+  nonce?: string;
+  gasPrice?: string;
+  transactionHash?: string;
 }

--- a/src/commands/transaction/transaction-command.type.ts
+++ b/src/commands/transaction/transaction-command.type.ts
@@ -1,0 +1,6 @@
+import { NetworkAndKeyOption } from "../shared";
+
+export interface TransactionCancelCommand extends NetworkAndKeyOption {
+  nonce: string;
+  gas: string;
+}

--- a/src/implementations/transaction/index.ts
+++ b/src/implementations/transaction/index.ts
@@ -1,0 +1,1 @@
+export * from "./transaction";

--- a/src/implementations/transaction/transaction.test.ts
+++ b/src/implementations/transaction/transaction.test.ts
@@ -2,8 +2,7 @@ import { cancelTransaction } from "./transaction";
 import { getWallet } from "../utils/wallet";
 import path from "path";
 import signale from "signale";
-import { BigNumber, Wallet } from "ethers/lib/ethers";
-import { Console } from "console";
+import { BigNumber } from "ethers/lib/ethers";
 jest.mock("../utils/wallet");
 
 const mockGetWallet = getWallet as jest.Mock;

--- a/src/implementations/transaction/transaction.test.ts
+++ b/src/implementations/transaction/transaction.test.ts
@@ -1,0 +1,46 @@
+import { cancelTransaction } from "./transaction";
+import { getWallet } from "../utils/wallet";
+import path from "path";
+import signale from "signale";
+jest.mock("../utils/wallet");
+
+const mockGetWallet = getWallet as jest.Mock;
+
+describe("document-store", () => {
+  describe("cancelTransaction", () => {
+    const signaleSuccessSpy = jest.spyOn(signale, "success");
+    const signaleErrorSpy = jest.spyOn(signale, "error");
+
+    it("success in canceling transaction", async () => {
+      const mockSendTransaction = jest.fn();
+      mockSendTransaction.mockResolvedValue("success");
+      mockGetWallet.mockResolvedValue({
+        sendTransaction: mockSendTransaction,
+        address: "0x00",
+      });
+      await cancelTransaction({
+        nonce: "3",
+        gas: "300",
+        network: "ropsten",
+        keyFile: path.resolve(__dirname, "./key.file"),
+      });
+      expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "Transaction has been cancelled");
+    });
+
+    it("error in cancelling transaction due to transaction status completed", async () => {
+      const mockSendTransaction = jest.fn();
+      mockSendTransaction.mockRejectedValue(new Error("nonce has already been used"));
+      mockGetWallet.mockResolvedValue({
+        sendTransaction: mockSendTransaction,
+        address: "0x00",
+      });
+      await cancelTransaction({
+        nonce: "3",
+        gas: "300",
+        network: "ropsten",
+        keyFile: path.resolve(__dirname, "./key.file"),
+      });
+      expect(signaleErrorSpy).toHaveBeenNthCalledWith(1, "nonce has already been used");
+    });
+  });
+});

--- a/src/implementations/transaction/transaction.test.ts
+++ b/src/implementations/transaction/transaction.test.ts
@@ -2,6 +2,7 @@ import { cancelTransaction } from "./transaction";
 import { getWallet } from "../utils/wallet";
 import path from "path";
 import signale from "signale";
+import { BigNumber } from "ethers";
 jest.mock("../utils/wallet");
 
 const mockGetWallet = getWallet as jest.Mock;
@@ -11,7 +12,7 @@ describe("document-store", () => {
     const signaleSuccessSpy = jest.spyOn(signale, "success");
     const signaleErrorSpy = jest.spyOn(signale, "error");
 
-    it("success in canceling transaction", async () => {
+    it("success in canceling transaction using nonce and gas", async () => {
       const mockSendTransaction = jest.fn();
       mockSendTransaction.mockResolvedValue("success");
       mockGetWallet.mockResolvedValue({
@@ -20,7 +21,29 @@ describe("document-store", () => {
       });
       await cancelTransaction({
         nonce: "3",
-        gas: "300",
+        gasPrice: "300",
+        network: "ropsten",
+        keyFile: path.resolve(__dirname, "./key.file"),
+      });
+      expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "Transaction has been cancelled");
+    });
+
+    it("success in canceling transaction using transaction hash", async () => {
+      const mockGetTransaction = jest.fn();
+      mockGetTransaction.mockResolvedValue({
+        nonce: 3,
+        gasPrice: BigNumber.from(300),
+      });
+      const mockSendTransaction = jest.fn();
+      mockSendTransaction.mockResolvedValue("success");
+
+      mockGetWallet.mockResolvedValue({
+        sendTransaction: mockSendTransaction,
+        provider: { getTransaction: mockGetTransaction },
+        address: "0x00",
+      });
+      await cancelTransaction({
+        transactionHash: "0x00",
         network: "ropsten",
         keyFile: path.resolve(__dirname, "./key.file"),
       });
@@ -36,7 +59,7 @@ describe("document-store", () => {
       });
       await cancelTransaction({
         nonce: "3",
-        gas: "300",
+        gasPrice: "300",
         network: "ropsten",
         keyFile: path.resolve(__dirname, "./key.file"),
       });

--- a/src/implementations/transaction/transaction.ts
+++ b/src/implementations/transaction/transaction.ts
@@ -21,19 +21,24 @@ export const cancelTransaction = async ({
 }: TransactionCancelCommand): Promise<void> => {
   try {
     const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
+    let transactionNonce = nonce;
+    let transactionGasPrice = gasPrice;
 
     if (transactionHash) {
       const currentTransaction = await wallet.provider.getTransaction(transactionHash);
-      nonce = currentTransaction.nonce.toString();
-      gasPrice = currentTransaction.gasPrice.mul(2).toString();
+      signale.info(
+        `Transaction detail retrieved. Nonce: ${currentTransaction.nonce}, Gas-price: ${currentTransaction.gasPrice}`
+      );
+      transactionNonce = currentTransaction.nonce.toString();
+      transactionGasPrice = currentTransaction.gasPrice.mul(2).toString();
     }
 
-    if (nonce && gasPrice) {
+    if (transactionNonce && transactionGasPrice) {
       await wallet.sendTransaction({
         to: wallet.address,
         from: wallet.address,
-        nonce: BigNumber.from(parseFloat(nonce)),
-        gasPrice: BigNumber.from(parseFloat(gasPrice)),
+        nonce: BigNumber.from(parseFloat(transactionNonce)),
+        gasPrice: BigNumber.from(parseFloat(transactionGasPrice)),
       });
       signale.success(`Transaction has been cancelled`);
     } else {

--- a/src/implementations/transaction/transaction.ts
+++ b/src/implementations/transaction/transaction.ts
@@ -26,11 +26,11 @@ export const cancelTransaction = async ({
 
     if (transactionHash) {
       const currentTransaction = await wallet.provider.getTransaction(transactionHash);
-      signale.info(
-        `Transaction detail retrieved. Nonce: ${currentTransaction.nonce}, Gas-price: ${currentTransaction.gasPrice}`
-      );
-      transactionNonce = currentTransaction.nonce.toString();
-      transactionGasPrice = currentTransaction.gasPrice.mul(2).toString();
+      signale.info(`Transaction detail retrieved. Nonce: ${nonce}, Gas-price: ${gasPrice}`);
+      const currentTransactionNonce = currentTransaction.nonce;
+      const currentTransactionGasPrice = currentTransaction.gasPrice;
+      transactionNonce = currentTransactionNonce.toString();
+      transactionGasPrice = currentTransactionGasPrice.mul(2).toString();
     }
 
     if (transactionNonce && transactionGasPrice) {

--- a/src/implementations/transaction/transaction.ts
+++ b/src/implementations/transaction/transaction.ts
@@ -3,23 +3,42 @@ import { TransactionCancelCommand } from "../../commands/transaction/transaction
 import { getWallet } from "../utils/wallet";
 import { BigNumber } from "ethers";
 
+/*
+  The trick to “cancel” your pending transaction is by replacing the transaction with 
+  another 0 ETH transaction with a higher gas fee sending to yourself with the same nonce as the 
+  pending transaction. By having increasing the gas fee, it allow the miner to prioritize transactions 
+  that pay a higher gas fee.
+  (https://info.etherscan.com/how-to-cancel-ethereum-pending-transactions/)
+*/
 export const cancelTransaction = async ({
   network,
   key,
   keyFile,
   encryptedWalletPath,
   nonce,
-  gas,
+  gasPrice,
+  transactionHash,
 }: TransactionCancelCommand): Promise<void> => {
   try {
     const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
-    await wallet.sendTransaction({
-      to: wallet.address,
-      from: wallet.address,
-      nonce: BigNumber.from(parseFloat(nonce)),
-      gasPrice: BigNumber.from(parseFloat(gas)),
-    });
-    signale.success(`Transaction has been cancelled`);
+
+    if (transactionHash) {
+      const currentTransaction = await wallet.provider.getTransaction(transactionHash);
+      nonce = currentTransaction.nonce.toString();
+      gasPrice = currentTransaction.gasPrice.mul(2).toString();
+    }
+
+    if (nonce && gasPrice) {
+      await wallet.sendTransaction({
+        to: wallet.address,
+        from: wallet.address,
+        nonce: BigNumber.from(parseFloat(nonce)),
+        gasPrice: BigNumber.from(parseFloat(gasPrice)),
+      });
+      signale.success(`Transaction has been cancelled`);
+    } else {
+      signale.error(`Please indicate the transaction hash or the pending transaction's nonce and gas price`);
+    }
   } catch (e) {
     signale.error(e.message);
   }

--- a/src/implementations/transaction/transaction.ts
+++ b/src/implementations/transaction/transaction.ts
@@ -27,10 +27,8 @@ export const cancelTransaction = async ({
     if (transactionHash) {
       const currentTransaction = await wallet.provider.getTransaction(transactionHash);
       signale.info(`Transaction detail retrieved. Nonce: ${nonce}, Gas-price: ${gasPrice}`);
-      const currentTransactionNonce = currentTransaction.nonce;
-      const currentTransactionGasPrice = currentTransaction.gasPrice;
-      transactionNonce = currentTransactionNonce.toString();
-      transactionGasPrice = currentTransactionGasPrice.mul(2).toString();
+      transactionNonce = currentTransaction.nonce.toString();
+      transactionGasPrice = currentTransaction.gasPrice.mul(2).toString();
     }
 
     if (transactionNonce && transactionGasPrice) {

--- a/src/implementations/transaction/transaction.ts
+++ b/src/implementations/transaction/transaction.ts
@@ -1,0 +1,31 @@
+import { Transaction } from "@ethersproject/transactions";
+import signale from "signale";
+import { TransactionCancelCommand } from "../../commands/transaction/transaction-command.type";
+import { getWallet } from "../utils/wallet";
+
+export const cancelTransaction = async ({
+  network,
+  key,
+  keyFile,
+  encryptedWalletPath,
+  nonce,
+  gas,
+}: TransactionCancelCommand): Promise<void> => {
+  const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
+  //   to?: string;
+  //   from?: string;
+  //   nonce?: BigNumberish;
+  //   gasLimit?: BigNumberish;
+  //   gasPrice?: BigNumberish;
+  //   data?: BytesLike;
+  //   value?: BigNumberish;
+  //   chainId?: number;
+  console.log(wallet.address);
+  const transaction = wallet.sendTransaction({
+    to: wallet.address,
+    from: wallet.address,
+    nonce: nonce,
+    gasPrice: gas,
+  });
+  console.log(transaction);
+};

--- a/src/implementations/transaction/transaction.ts
+++ b/src/implementations/transaction/transaction.ts
@@ -26,7 +26,9 @@ export const cancelTransaction = async ({
 
     if (transactionHash) {
       const currentTransaction = await wallet.provider.getTransaction(transactionHash);
-      signale.info(`Transaction detail retrieved. Nonce: ${nonce}, Gas-price: ${gasPrice}`);
+      signale.info(
+        `Transaction detail retrieved. Nonce: ${currentTransaction.nonce}, Gas-price: ${currentTransaction.gasPrice}`
+      );
       transactionNonce = currentTransaction.nonce.toString();
       transactionGasPrice = currentTransaction.gasPrice.mul(2).toString();
     }

--- a/src/implementations/transaction/transaction.ts
+++ b/src/implementations/transaction/transaction.ts
@@ -1,7 +1,7 @@
-import { Transaction } from "@ethersproject/transactions";
 import signale from "signale";
 import { TransactionCancelCommand } from "../../commands/transaction/transaction-command.type";
 import { getWallet } from "../utils/wallet";
+import { BigNumber } from "ethers";
 
 export const cancelTransaction = async ({
   network,
@@ -11,21 +11,16 @@ export const cancelTransaction = async ({
   nonce,
   gas,
 }: TransactionCancelCommand): Promise<void> => {
-  const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
-  //   to?: string;
-  //   from?: string;
-  //   nonce?: BigNumberish;
-  //   gasLimit?: BigNumberish;
-  //   gasPrice?: BigNumberish;
-  //   data?: BytesLike;
-  //   value?: BigNumberish;
-  //   chainId?: number;
-  console.log(wallet.address);
-  const transaction = wallet.sendTransaction({
-    to: wallet.address,
-    from: wallet.address,
-    nonce: nonce,
-    gasPrice: gas,
-  });
-  console.log(transaction);
+  try {
+    const wallet = await getWallet({ key, keyFile, network, encryptedWalletPath });
+    await wallet.sendTransaction({
+      to: wallet.address,
+      from: wallet.address,
+      nonce: BigNumber.from(parseFloat(nonce)),
+      gasPrice: BigNumber.from(parseFloat(gas)),
+    });
+    signale.success(`Transaction has been cancelled`);
+  } catch (e) {
+    signale.error(e.message);
+  }
 };


### PR DESCRIPTION
Added CLI command to cancel a pending transaction.

You can test in an actual ethereum environment by creating a pending transaction using the command below. 

open-attestation document-store issue --address <document-store> --hash <merkleroot> —network ropsten --gps 0 --encrypted-wallet-path ../wallet.json

The command will create a transaction to issue the hash into document-store and set the gas price to be 0 forcing it to constant pending. From the etherscan u can get the pending transaction nonce to test the transaction cancel command
