### PR TITLE
fix: update ci context name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ workflows:
     jobs:
       - build:
           context:
-            - NPM Deployment
+            - deployment
 
 jobs:
   build:


### PR DESCRIPTION
Update ci context name to the new name `deployment`.