### PR TITLE
feat: add unwrapping feature to OA CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Example:
 ```bash
 open-attestation unwrap ./examples/v2/wrapped-documents/example.0.json
 
-✔  success   The document have been unwrapped
+✔  success   The document has been unwrapped
 ```
 
 The command will display the result in the console. If you need to save the file you can use the `--output-file` option.
@@ -171,7 +171,7 @@ Example:
 ```bash
 open-attestation unwrap ./examples/v2/wrapped-documents/example.0.json --output-file ./examples/v2/raw-documents/example.0.json
 
-✔  success   The document have been unwrapped
+✔  success   The document has been unwrapped
 ```
 
 If you need to unwrap a folder you will need to provide the `--output-dir` option to specify which folder the documents must be unwrapped in.
@@ -181,7 +181,7 @@ Example:
 ```bash
 open-attestation unwrap ./examples/v2/wrapped-documents --output-dir ./examples/v2/raw-documents
 
-✔  success   The documents have been unwrapped into folder ./examples/v2/raw-documents
+✔  success   The documents have been individually unwrapped into folder ./examples/v2/raw-documents
 ```
 
 ### Document privacy filter

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ npx -p @govtechsg/open-attestation-cli open-attestation <arguments>
 | Encrypt document                           | ❎          | ❎     | ❎      |
 | Decrypt document                           | ❎          | ❎     | ❎      |
 | Wrap document                              | ❎          | ❎     | ❎      |
+| Unwrap document                            | ❎          | ❎     | ❎      |
 | Verify document                            | ❎          | ❎     | ❎      |
 | Change holder (Title Escrow)               | ✔           | ✔      | ✔       |
 | Nominate change of owner (Title Escrow)    | ✔           | ✔      | ✔       |
@@ -150,6 +151,38 @@ open-attestation wrap ./examples/raw-documents/ ./examples/wrapped-documents/ --
 ```
 
 > **_NOTE:_** For transferable records, you should wrap them individually as each of them would be minted to a unique title escrow that represents the beneficiary and holder entities of the document. For more information about title escrow, refer [here](https://www.openattestation.com/docs/integrator-section/transferable-record/title-escrow).
+
+### Unwrapping documents
+
+This command processes a document in the input directory. It will unwrap the wrapped document to its raw document form to be displayed on the console.
+
+Example:
+
+```bash
+open-attestation unwrap ./examples/v2/wrapped-documents/example.0.json
+
+✔  success   The document have been unwrapped
+```
+
+The command will display the result in the console. If you need to save the file you can use the `--output-file` option.
+
+Example:
+
+```bash
+open-attestation unwrap ./examples/v2/wrapped-documents/example.0.json --output-file ./examples/v2/raw-documents/example.0.json
+
+✔  success   The document have been unwrapped
+```
+
+If you need to unwrap a folder you will need to provide the `--output-dir` option to specify which folder the documents must be unwrapped in.
+
+Example:
+
+```bash
+open-attestation unwrap ./examples/v2/wrapped-documents --output-dir ./examples/v2/raw-documents
+
+✔  success   The documents have been unwrapped into folder ./examples/v2/raw-documents
+```
 
 ### Document privacy filter
 

--- a/performance-tests/wrap-performance-test.ts
+++ b/performance-tests/wrap-performance-test.ts
@@ -1,4 +1,5 @@
-import { Output, wrap } from "../src/implementations/wrap";
+import { wrap } from "../src/implementations/wrap";
+import { Output } from "../src/implementations/utils/disk";
 import { performance } from "perf_hooks";
 import { existsSync, mkdirSync, rmdirSync, promises } from "fs";
 import { SchemaId } from "@govtechsg/open-attestation";

--- a/src/__tests__/fixture/2.0/unwrapped-example.1.json
+++ b/src/__tests__/fixture/2.0/unwrapped-example.1.json
@@ -1,0 +1,22 @@
+{
+  "id": "53b75bbe",
+  "name": "Govtech Demo Certificate",
+  "$template": {
+    "name": "GOVTECH_DEMO",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://demo-renderer.opencerts.io"
+  },
+  "issuers": [
+    {
+      "name": "Govtech",
+      "documentStore": "0x718B518565B81097b185661EBba3966Ff32A0039",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.openattestation.com"
+      }
+    }
+  ],
+  "recipient": {
+    "name": "Your Name"
+  }
+}

--- a/src/__tests__/fixture/2.0/unwrapped-example.2.json
+++ b/src/__tests__/fixture/2.0/unwrapped-example.2.json
@@ -1,0 +1,33 @@
+{
+  "$template": {
+    "name": "main",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://tutorial-renderer.openattestation.com"
+  },
+  "recipient": {
+    "name": "John Doe"
+  },
+  "issuers": [
+    {
+      "name": "Demo Issuer",
+      "documentStore": "0xBBb55Bd1D709955241CAaCb327A765e2b6D69c8b",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "few-green-cat.sandbox.openattestation.com"
+      }
+    }
+  ],
+  "signatoryAuthentication": {
+    "signature": "-",
+    "actualDateTime": "2020-05-29T09:46:34Z",
+    "statement": "The undersigned hereby declares that the above-stated information is correct and that the goods exported to [importer] comply with the origin requirements",
+    "description": "The undersigned hereby declares that the above-stated information"
+  },
+  "name": "Test Certificate",
+  "issueLocation": { "iD": "None", "name": "Adelaide" },
+  "status": "issued",
+  "isPreferential": true,
+  "freeTradeAgreement": "Test",
+  "iD": "Test",
+  "issueDateTime": "IssueDate"
+}

--- a/src/__tests__/fixture/2.0/wrapped-example.1.json
+++ b/src/__tests__/fixture/2.0/wrapped-example.1.json
@@ -1,0 +1,31 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "id": "189b1a8c-37a5-41d3-81be-a8937a80ed87:string:53b75bbe",
+    "name": "ff654adf-a018-49e3-bb63-87ffd070e901:string:Govtech Demo Certificate",
+    "$template": {
+      "name": "3400b6f8-2c7f-4f41-9c00-764e34fa3408:string:GOVTECH_DEMO",
+      "type": "4e4a1393-7051-451d-a83a-f71731b2a344:string:EMBEDDED_RENDERER",
+      "url": "d267a44b-66c6-4b7c-a249-a2910c6f35a8:string:https://demo-renderer.opencerts.io"
+    },
+    "issuers": [
+      {
+        "name": "797a7a59-9e89-47c1-b5db-e7f2134d76bf:string:Govtech",
+        "documentStore": "0276bfc6-01e8-4933-abbb-525698cc15a1:string:0x718B518565B81097b185661EBba3966Ff32A0039",
+        "identityProof": {
+          "type": "16f50562-241e-4200-b118-7af692d0d04d:string:DNS-TXT",
+          "location": "cacf4c12-a038-4419-8083-5b886cf5a410:string:example.openattestation.com"
+        }
+      }
+    ],
+    "recipient": {
+      "name": "38587afb-16c0-48b4-8bfb-9d87ad430641:string:Your Name"
+    }
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "cc7362fb3dc939987cae9e86900ade8c1d687b0c3419de776cd559c3eb211614",
+    "proof": [],
+    "merkleRoot": "cc7362fb3dc939987cae9e86900ade8c1d687b0c3419de776cd559c3eb211614"
+  }
+}

--- a/src/__tests__/fixture/2.0/wrapped-example.2.json
+++ b/src/__tests__/fixture/2.0/wrapped-example.2.json
@@ -1,0 +1,45 @@
+{
+  "version": "https://schema.openattestation.com/2.0/schema.json",
+  "data": {
+    "$template": {
+      "name": "f25e1526-2b29-4c86-a037-5432aad11160:string:main",
+      "type": "b6776f4f-eb98-4bb0-a4d3-53cb028e57df:string:EMBEDDED_RENDERER",
+      "url": "72db66a4-d9c4-4914-8082-8989e35c5575:string:https://tutorial-renderer.openattestation.com"
+    },
+    "recipient": {
+      "name": "d8c26d1e-8b90-49c1-a181-e8526a9912da:string:John Doe"
+    },
+    "issuers": [
+      {
+        "name": "ee379bb3-e5a6-466b-acec-4bc84c1cf128:string:Demo Issuer",
+        "documentStore": "fe02631a-88af-404c-a35c-b4eb7c983b39:string:0xBBb55Bd1D709955241CAaCb327A765e2b6D69c8b",
+        "identityProof": {
+          "type": "cfa8ec95-714c-4a61-9ab3-6dfa4b7f408f:string:DNS-TXT",
+          "location": "33448be7-0746-4cd2-a741-659774799393:string:few-green-cat.sandbox.openattestation.com"
+        }
+      }
+    ],
+    "signatoryAuthentication": {
+      "signature": "7eb0a2bd-5250-4ec0-a660-02d7d0ec7ce2:string:-",
+      "actualDateTime": "3d7bc93b-1e68-404a-81c4-24f063c1c35c:string:2020-05-29T09:46:34Z",
+      "statement": "fd72e086-343f-45b9-95bd-e471717777ed:string:The undersigned hereby declares that the above-stated information is correct and that the goods exported to [importer] comply with the origin requirements",
+      "description": "b24f5a7f-80f3-4a55-9a1b-5304af4b16fb:string:The undersigned hereby declares that the above-stated information"
+    },
+    "name": "a460e8b2-7269-4ead-aec0-66be57f75d5f:string:Test Certificate",
+    "issueLocation": {
+      "iD": "5d7fb90a-b579-475e-b899-a035be95022d:string:None",
+      "name": "e4b9083b-4c02-4855-9dd2-cb0670080ec9:string:Adelaide"
+    },
+    "status": "a03a3377-a34c-42b9-9a70-f9f74a50e7d4:string:issued",
+    "isPreferential": "e3e18fc5-c100-4f3b-8c13-7632fcb388ab:boolean:true",
+    "freeTradeAgreement": "ee7b9c4d-217e-4dd0-b7fa-dd47053c2f5f:string:Test",
+    "iD": "e855cb01-6688-46d8-b7e0-b9a89293262a:string:Test",
+    "issueDateTime": "8281cecd-4433-4202-953e-eac3ac887e1c:string:IssueDate"
+  },
+  "signature": {
+    "type": "SHA3MerkleProof",
+    "targetHash": "cea06d5bcb7650527308f74a4bffe13272989a2c33c8a7513f38b0c0c9527a52",
+    "proof": [],
+    "merkleRoot": "cea06d5bcb7650527308f74a4bffe13272989a2c33c8a7513f38b0c0c9527a52"
+  }
+}

--- a/src/__tests__/unwrap.test.ts
+++ b/src/__tests__/unwrap.test.ts
@@ -35,7 +35,11 @@ describe("unwrap", () => {
         throw new Error(`unhandled ${path} in spy`);
       });
 
-      const unwrappedDocumentCount = await unwrapIndividualDocuments("./fixture/2.0", "./fixture/2.0", Output.Directory);
+      const unwrappedDocumentCount = await unwrapIndividualDocuments(
+        "./fixture/2.0",
+        "./fixture/2.0",
+        Output.Directory
+      );
 
       expect(unwrappedDocumentCount).toEqual(1);
     });
@@ -76,7 +80,11 @@ describe("unwrap", () => {
         throw new Error(`unhandled ${path} in spy`);
       });
 
-      const unwrappedDocumentCount = await unwrapIndividualDocuments("./fixture/2.0", "./fixture/2.0", Output.Directory);
+      const unwrappedDocumentCount = await unwrapIndividualDocuments(
+        "./fixture/2.0",
+        "./fixture/2.0",
+        Output.Directory
+      );
 
       expect(unwrappedDocumentCount).toEqual(2);
     });

--- a/src/__tests__/unwrap.test.ts
+++ b/src/__tests__/unwrap.test.ts
@@ -35,10 +35,9 @@ describe("unwrap", () => {
         throw new Error(`unhandled ${path} in spy`);
       });
 
-      const oaDocuments = await unwrapIndividualDocuments("./fixture/2.0", "./fixture/2.0", Output.Directory);
-      const unwrappedDocument = oaDocuments[0];
+      const unwrappedDocumentCount = await unwrapIndividualDocuments("./fixture/2.0", "./fixture/2.0", Output.Directory);
 
-      expect(unwrappedDocument).toEqual(unwrappedFileFixture1);
+      expect(unwrappedDocumentCount).toEqual(1);
     });
   });
 
@@ -77,11 +76,9 @@ describe("unwrap", () => {
         throw new Error(`unhandled ${path} in spy`);
       });
 
-      const oaDocuments = await unwrapIndividualDocuments("./fixture/2.0", "./fixture/2.0", Output.Directory);
+      const unwrappedDocumentCount = await unwrapIndividualDocuments("./fixture/2.0", "./fixture/2.0", Output.Directory);
 
-      const expectedDocuments = [unwrappedFileFixture1, unwrappedFileFixture2];
-
-      expect(oaDocuments).toEqual(expectedDocuments);
+      expect(unwrappedDocumentCount).toEqual(2);
     });
   });
 });

--- a/src/__tests__/unwrap.test.ts
+++ b/src/__tests__/unwrap.test.ts
@@ -27,9 +27,8 @@ describe("unwrap", () => {
       jest.spyOn(fs, "writeFileSync").mockImplementation((path, document) => {
         if (typeof path !== "string") throw new Error("path is not string");
         if (path.includes("wrapped-example.1.json")) {
-          // sorry lint I did my best to avoid that
+          const documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
           // eslint-disable-next-line jest/no-conditional-expect
-          let documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
           expect(documentForCompare).toMatchObject(unwrappedFileFixture1);
           return;
         }
@@ -65,15 +64,13 @@ describe("unwrap", () => {
       jest.spyOn(fs, "writeFileSync").mockImplementation((path, document) => {
         if (typeof path !== "string") throw new Error("path is not string");
         if (path.includes("wrapped-example.1.json")) {
-          // sorry lint I did my best to avoid that
+          const documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
           // eslint-disable-next-line jest/no-conditional-expect
-          let documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
           expect(documentForCompare).toMatchObject(unwrappedFileFixture1);
           return;
         } else if (path.includes("wrapped-example.2.json")) {
-          // sorry lint I did my best to avoid that
+          const documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
           // eslint-disable-next-line jest/no-conditional-expect
-          let documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
           expect(documentForCompare).toMatchObject(unwrappedFileFixture2);
           return;
         }

--- a/src/__tests__/unwrap.test.ts
+++ b/src/__tests__/unwrap.test.ts
@@ -1,0 +1,90 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+import { unwrapIndividualDocuments, Output } from "../implementations/unwrap";
+import fs from "fs";
+import wrappedFileFixture1 from "./fixture/2.0/wrapped-example.1.json";
+import unwrappedFileFixture1 from "./fixture/2.0/unwrapped-example.1.json";
+import wrappedFileFixture2 from "./fixture/2.0/wrapped-example.2.json";
+import unwrappedFileFixture2 from "./fixture/2.0/unwrapped-example.2.json";
+
+jest.mock("fs");
+
+describe("unwrap", () => {
+  describe("unwrapIndividualDocuments", () => {
+    it("unwrap a single wrapped document", async () => {
+      // @ts-ignore
+      jest.spyOn(fs, "lstatSync").mockReturnValue({ isDirectory: () => true });
+      jest.spyOn(fs, "readdir").mockImplementation((options, callback) => {
+        // @ts-ignore
+        return callback(null, ["wrapped-example.1.json"]);
+      });
+      jest.spyOn(fs, "readFileSync").mockImplementation((path) => {
+        // @ts-ignore
+        if (path.includes("wrapped-example.1.json")) {
+          return JSON.stringify(wrappedFileFixture1);
+        }
+        return "";
+      });
+      jest.spyOn(fs, "writeFileSync").mockImplementation((path, document) => {
+        if (typeof path !== "string") throw new Error("path is not string");
+        if (path.includes("wrapped-example.1.json")) {
+          // sorry lint I did my best to avoid that
+          // eslint-disable-next-line jest/no-conditional-expect
+          let documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
+          expect(documentForCompare).toMatchObject(unwrappedFileFixture1);
+          return;
+        }
+        throw new Error(`unhandled ${path} in spy`);
+      });
+
+      const oaDocuments = await unwrapIndividualDocuments("./fixture/2.0", "./fixture/2.0", Output.Directory);
+      const unwrappedDocument = oaDocuments[0];
+
+      expect(unwrappedDocument).toEqual(unwrappedFileFixture1);
+    });
+  });
+
+  describe("unwrapMultipleDocuments", () => {
+    it("unwrap multiple wrapped documents", async () => {
+      // @ts-ignore
+      jest.spyOn(fs, "lstatSync").mockReturnValue({ isDirectory: () => true });
+      jest.spyOn(fs, "readdir").mockImplementation((options, callback) => {
+        // @ts-ignore
+        return callback(null, ["wrapped-example.1.json", "wrapped-example.2.json"]);
+      });
+      jest.spyOn(fs, "readFileSync").mockImplementation((path) => {
+        // @ts-ignore
+        if (path.includes("wrapped-example.1.json")) {
+          return JSON.stringify(wrappedFileFixture1);
+        }
+        // @ts-ignore
+        else if (path.includes("wrapped-example.2.json")) {
+          return JSON.stringify(wrappedFileFixture2);
+        }
+        return "";
+      });
+      jest.spyOn(fs, "writeFileSync").mockImplementation((path, document) => {
+        if (typeof path !== "string") throw new Error("path is not string");
+        if (path.includes("wrapped-example.1.json")) {
+          // sorry lint I did my best to avoid that
+          // eslint-disable-next-line jest/no-conditional-expect
+          let documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
+          expect(documentForCompare).toMatchObject(unwrappedFileFixture1);
+          return;
+        } else if (path.includes("wrapped-example.2.json")) {
+          // sorry lint I did my best to avoid that
+          // eslint-disable-next-line jest/no-conditional-expect
+          let documentForCompare = JSON.parse(JSON.parse(JSON.stringify(document)));
+          expect(documentForCompare).toMatchObject(unwrappedFileFixture2);
+          return;
+        }
+        throw new Error(`unhandled ${path} in spy`);
+      });
+
+      const oaDocuments = await unwrapIndividualDocuments("./fixture/2.0", "./fixture/2.0", Output.Directory);
+
+      const expectedDocuments = [unwrappedFileFixture1, unwrappedFileFixture2];
+
+      expect(oaDocuments).toEqual(expectedDocuments);
+    });
+  });
+});

--- a/src/__tests__/unwrap.test.ts
+++ b/src/__tests__/unwrap.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { unwrapIndividualDocuments, Output } from "../implementations/unwrap";
+import { unwrapIndividualDocuments } from "../implementations/unwrap";
+import { Output } from "../implementations/utils/disk";
 import fs from "fs";
 import wrappedFileFixture1 from "./fixture/2.0/wrapped-example.1.json";
 import unwrappedFileFixture1 from "./fixture/2.0/unwrapped-example.1.json";

--- a/src/__tests__/wrap.test.ts
+++ b/src/__tests__/wrap.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { appendProofToDocuments, merkleHashmap, Output } from "../implementations/wrap";
+import { appendProofToDocuments, merkleHashmap } from "../implementations/wrap";
+import { Output } from "../implementations/utils/disk";
 import fs from "fs";
 import { utils } from "@govtechsg/open-attestation";
 

--- a/src/commands/unwrap.ts
+++ b/src/commands/unwrap.ts
@@ -1,7 +1,7 @@
 import { Argv } from "yargs";
 import signale from "signale";
-import { Output, unwrap } from "../implementations/unwrap";
-import { isDir } from "../implementations/utils/disk";
+import { unwrap } from "../implementations/unwrap";
+import { isDir, Output } from "../implementations/utils/disk";
 interface UnwrapCommand {
   wrappedDocumentsPath: string;
   outputDir?: string;

--- a/src/commands/unwrap.ts
+++ b/src/commands/unwrap.ts
@@ -1,0 +1,112 @@
+import { Argv } from "yargs";
+import signale from "signale";
+import { Output, unwrap } from "../implementations/unwrap";
+import { transformValidationErrors } from "../implementations/wrap/ajvErrorTransformer";
+import { isDir } from "../implementations/utils/disk";
+import { SchemaId } from "@govtechsg/open-attestation";
+
+interface UnwrapCommand {
+  wrappedDocumentsPath: string;
+  outputDir?: string;
+  outputFile?: string;
+  schema?: string;
+  openAttestationV3: boolean;
+  unwrap: boolean;
+  silent?: boolean;
+  batched: boolean;
+}
+
+export const command = "unwrap <wrapped-documents-path> [options]";
+
+export const describe = "Unwrap a document";
+
+export const builder = (yargs: Argv): Argv =>
+  yargs
+    .positional("wrapped-documents-path", {
+      description: "Directory containing the single issued wrapped document file",
+      normalize: true,
+      type: "string",
+    })
+    .option("schema", {
+      alias: "s",
+      description: "Path or URL to custom schema",
+      type: "string",
+    })
+    .option("open-attestation-v2", {
+      alias: "oav2",
+      conflicts: "open-attestation-v3",
+    })
+    .option("open-attestation-v3", {
+      alias: "oav3",
+      conflicts: "open-attestation-v2",
+    })
+    .option("output-file", {
+      alias: "of",
+      description: "Write output to a file. Only use when <unwrapped-documents-dir> is a document",
+      type: "string",
+      conflicts: "output-dir",
+    })
+    .option("output-dir", {
+      alias: "od",
+      description: "Write output to a directory",
+      type: "string",
+      conflicts: "output-file",
+    })
+    .option("silent", {
+      alias: "silent",
+      description: "Disable console outputs when outputting to stdout",
+      type: "boolean",
+    })
+    .option("batched", {
+      description: "Indicate whether documents must be wrap together or individually",
+      type: "boolean",
+      default: true,
+    });
+
+export const handler = async (args: UnwrapCommand): Promise<void | undefined> => {
+  try {
+    const outputPathType = args.outputDir ? Output.Directory : args.outputFile ? Output.File : Output.StdOut;
+    const outputPath = args.outputDir || args.outputFile; // undefined when we use std out
+
+    // when input type is directory, output type must only be directory
+    if (isDir(args.wrappedDocumentsPath) && outputPathType !== Output.Directory) {
+      signale.error(
+        "Output path type can only be directory when using directory as raw documents path, use --output-dir"
+      );
+      process.exit(1);
+    }
+
+    // when outputting to stdout, disable signale so that the logs do not interfere
+    if (args.silent) {
+      signale.disable();
+    }
+
+    // if output to a file or stdout, we handle only one file. In that case we disable the batch mode
+    const batched = outputPathType !== Output.Directory ? false : args.batched;
+    if (!batched && args.batched) {
+      signale.warn("Detected single file: batch mode disabled.");
+    }
+
+    const rawDocs = await unwrap({
+      inputPath: args.wrappedDocumentsPath,
+      outputPath,
+      schemaPath: args.schema,
+      version: args.openAttestationV3 ? SchemaId.v3 : SchemaId.v2,
+      unwrap: args.unwrap,
+      outputPathType,
+      batched,
+    });
+
+    if (rawDocs) {
+      signale.success(`The document have been unwrapped`);
+    }
+  } catch (err) {
+    signale.error(err.message);
+    if (err.validationErrors) {
+      for (const error of transformValidationErrors(err.validationErrors)) {
+        signale.error(error);
+      }
+    }
+    process.exit(1);
+  }
+};

--- a/src/commands/unwrap.ts
+++ b/src/commands/unwrap.ts
@@ -64,7 +64,11 @@ export const handler = async (args: UnwrapCommand): Promise<void | undefined> =>
     });
 
     if (rawDocs) {
-      signale.success(`The document have been unwrapped`);
+      if (rawDocs.length > 1) {
+        signale.success(`The documents have been unwrapped into folder ${outputPath}`);
+      } else {
+        signale.success(`The document have been unwrapped`);
+      }
     }
   } catch (err) {
     signale.error(err.message);

--- a/src/commands/unwrap.ts
+++ b/src/commands/unwrap.ts
@@ -57,17 +57,17 @@ export const handler = async (args: UnwrapCommand): Promise<void | undefined> =>
       signale.disable();
     }
 
-    const rawDocs = await unwrap({
+    const rawDocsCount = await unwrap({
       inputPath: args.wrappedDocumentsPath,
       outputPath,
       outputPathType,
     });
 
-    if (rawDocs) {
-      if (rawDocs.length > 1) {
-        signale.success(`The documents have been unwrapped into folder ${outputPath}`);
+    if (rawDocsCount) {
+      if (rawDocsCount > 1) {
+        signale.success(`The documents have been individually unwrapped into folder ${outputPath}`);
       } else {
-        signale.success(`The document have been unwrapped`);
+        signale.success(`The document has been unwrapped`);
       }
     }
   } catch (err) {

--- a/src/commands/unwrap.ts
+++ b/src/commands/unwrap.ts
@@ -1,7 +1,6 @@
 import { Argv } from "yargs";
 import signale from "signale";
 import { Output, unwrap } from "../implementations/unwrap";
-import { transformValidationErrors } from "../implementations/wrap/ajvErrorTransformer";
 import { isDir } from "../implementations/utils/disk";
 interface UnwrapCommand {
   wrappedDocumentsPath: string;
@@ -72,11 +71,6 @@ export const handler = async (args: UnwrapCommand): Promise<void | undefined> =>
     }
   } catch (err) {
     signale.error(err.message);
-    if (err.validationErrors) {
-      for (const error of transformValidationErrors(err.validationErrors)) {
-        signale.error(error);
-      }
-    }
     process.exit(1);
   }
 };

--- a/src/commands/wrap.ts
+++ b/src/commands/wrap.ts
@@ -1,8 +1,8 @@
 import { Argv } from "yargs";
 import signale from "signale";
-import { Output, wrap } from "../implementations/wrap";
+import { wrap } from "../implementations/wrap";
 import { transformValidationErrors } from "../implementations/wrap/ajvErrorTransformer";
-import { isDir } from "../implementations/utils/disk";
+import { isDir, Output } from "../implementations/utils/disk";
 import { SchemaId } from "@govtechsg/open-attestation";
 
 interface WrapCommand {

--- a/src/implementations/unwrap/index.ts
+++ b/src/implementations/unwrap/index.ts
@@ -1,0 +1,1 @@
+export * from "./unwrap";

--- a/src/implementations/unwrap/unwrap.ts
+++ b/src/implementations/unwrap/unwrap.ts
@@ -1,13 +1,7 @@
-import { documentsInDirectory, readOpenAttestationFile, writeOutput } from "../utils/disk";
+import { documentsInDirectory, readOpenAttestationFile, writeOutput, Output } from "../utils/disk";
 import mkdirp from "mkdirp";
 import { getData, OpenAttestationDocument } from "@govtechsg/open-attestation";
 import path from "path";
-
-export enum Output {
-  File,
-  Directory,
-  StdOut,
-}
 
 export const unwrapIndividualDocuments = async (
   wrappedDocumentPath: string,

--- a/src/implementations/unwrap/unwrap.ts
+++ b/src/implementations/unwrap/unwrap.ts
@@ -1,0 +1,168 @@
+import { documentsInDirectory, readOpenAttestationFile, writeDocumentToDisk } from "../utils/disk";
+import { dirSync } from "tmp";
+import mkdirp from "mkdirp";
+import { getData, SchemaId, OpenAttestationDocument } from "@govtechsg/open-attestation";
+import path from "path";
+import fetch from "node-fetch";
+import Ajv, { AnySchemaObject, ErrorObject, ValidateFunction } from "ajv";
+import addFormats from "ajv-formats";
+
+class SchemaValidationError extends Error {
+  constructor(message: string, public validationErrors: ErrorObject[], public document: any) {
+    super(message);
+  }
+}
+
+interface Schema {
+  $id: string;
+}
+
+export enum Output {
+  File,
+  Directory,
+  StdOut,
+}
+
+const remoteLoadSchema = async (uri: string): Promise<AnySchemaObject> => {
+  const response = await fetch(uri);
+  console.log({ uri });
+  const r = await response.json();
+  console.log({ uri });
+  return r;
+};
+
+const ajv = new Ajv({ loadSchema: remoteLoadSchema, allowUnionTypes: true });
+addFormats(ajv);
+ajv.addKeyword("deprecationMessage");
+
+export const unwrapIndividualDocuments = async (
+  undigestedDocumentPath: string,
+  digestedDocumentDir: string | undefined,
+  version: SchemaId,
+  unwrap: boolean,
+  outputPathType: Output,
+  schema?: Schema
+): Promise<OpenAttestationDocument[]> => {
+  const oaArray: OpenAttestationDocument[] = [];
+  const documentFileNames = await documentsInDirectory(undigestedDocumentPath);
+  let compile: ValidateFunction | undefined;
+  if (schema) {
+    compile = await ajv.compileAsync(schema);
+  }
+
+  for (const file of documentFileNames) {
+    const unwrappedDocument = getData(readOpenAttestationFile(file));
+    oaArray.push(unwrappedDocument);
+
+    // Digest individual document
+    if (compile) {
+      const valid = compile(document);
+      if (!valid) {
+        throw new SchemaValidationError(
+          `Document ${path.resolve(file)} is not valid against the provided schema`,
+          compile.errors ?? [],
+          document
+        );
+      }
+    }
+
+    try {
+      // Write digested document to new directory
+      writeOutput({
+        outputPathType,
+        digestedDocumentPath: digestedDocumentDir,
+        file,
+        document: unwrappedDocument,
+      });
+    } catch (e) {
+      throw e;
+    }
+  }
+  return oaArray;
+};
+
+const writeOutput = ({
+  outputPathType,
+  digestedDocumentPath,
+  file,
+  document,
+}: {
+  outputPathType: Output;
+  digestedDocumentPath?: string;
+  file: string;
+  document: any;
+}): void => {
+  if (outputPathType === Output.File && digestedDocumentPath) {
+    writeDocumentToDisk(path.parse(digestedDocumentPath).dir, path.parse(digestedDocumentPath).base, document);
+  } else if (outputPathType === Output.Directory && digestedDocumentPath) {
+    writeDocumentToDisk(digestedDocumentPath, path.parse(file).base, document);
+  } else {
+    console.log(JSON.stringify(document, undefined, 2)); // print to console, no file created
+  }
+};
+
+const loadSchema = (schemaPath?: string): Promise<Schema | undefined> => {
+  const checkSchema = (schema: any): Schema => {
+    if (!schema.$id) {
+      throw new Error("Invalid schema, you must provide an $id property to your schema");
+    }
+    return schema;
+  };
+  if (schemaPath && (schemaPath.startsWith("http://") || schemaPath.startsWith("https://"))) {
+    return fetch(schemaPath)
+      .then((response) => response.json())
+      .then(checkSchema);
+  } else if (schemaPath) {
+    return import(path.resolve(schemaPath)).then(checkSchema);
+  }
+  return Promise.resolve(undefined);
+};
+
+interface UnwrapArguments {
+  inputPath: string;
+  outputPath?: string;
+  schemaPath?: string;
+  version: SchemaId;
+  unwrap: boolean;
+  batched: boolean;
+  outputPathType: Output;
+  dnsTxt?: string;
+  documentStore?: string;
+  templateUrl?: string;
+}
+
+export const unwrap = async ({
+  inputPath,
+  outputPath,
+  schemaPath,
+  version,
+  unwrap,
+  batched,
+  outputPathType,
+}: UnwrapArguments): Promise<OpenAttestationDocument[] | undefined> => {
+  // Create output dir
+  if (outputPath) {
+    mkdirp.sync(outputPathType === Output.File ? path.parse(outputPath).dir : outputPath);
+  }
+
+  // Create intermediate dir
+  const { name: intermediateDir, removeCallback } = dirSync({
+    unsafeCleanup: true,
+  });
+
+  // Phase 1: For each document, read content, digest and write to file
+  const schema = await loadSchema(schemaPath);
+  const rawDocumentsArray = await unwrapIndividualDocuments(
+    inputPath,
+    // if we dont batch document we can directly write to the destination folder. Otherwise we need to output in a temporary folder to compute the merkle root later
+    batched ? intermediateDir : outputPath,
+    version,
+    unwrap,
+    batched ? Output.Directory : outputPathType,
+    schema
+  );
+
+  // Remove intermediate dir
+  removeCallback();
+  return rawDocumentsArray;
+};

--- a/src/implementations/unwrap/unwrap.ts
+++ b/src/implementations/unwrap/unwrap.ts
@@ -1,4 +1,9 @@
-import { documentsInDirectory, readOpenAttestationFile, writeDocumentToDisk } from "../utils/disk";
+import {
+  documentsInDirectory,
+  readOpenAttestationFile,
+  writeDocumentToDisk,
+  printDocumentToConsole,
+} from "../utils/disk";
 import mkdirp from "mkdirp";
 import { getData, OpenAttestationDocument } from "@govtechsg/open-attestation";
 import path from "path";
@@ -13,7 +18,7 @@ export const unwrapIndividualDocuments = async (
   wrappedDocumentPath: string,
   unwrappedDocumentDir: string | undefined,
   outputPathType: Output
-): Promise<OpenAttestationDocument[]> => {
+): Promise<number> => {
   const oaArray: OpenAttestationDocument[] = [];
   const documentFileNames = await documentsInDirectory(wrappedDocumentPath);
 
@@ -33,7 +38,7 @@ export const unwrapIndividualDocuments = async (
       throw e;
     }
   }
-  return oaArray;
+  return oaArray.length;
 };
 
 const writeOutput = ({
@@ -52,7 +57,7 @@ const writeOutput = ({
   } else if (outputPathType === Output.Directory && unwrappedDocumentPath) {
     writeDocumentToDisk(unwrappedDocumentPath, path.parse(file).base, document);
   } else {
-    console.log(JSON.stringify(document, undefined, 2)); // print to console, no file created
+    printDocumentToConsole(document); // print to console, no file created
   }
 };
 
@@ -66,13 +71,11 @@ export const unwrap = async ({
   inputPath,
   outputPath,
   outputPathType,
-}: UnwrapArguments): Promise<OpenAttestationDocument[] | undefined> => {
+}: UnwrapArguments): Promise<number | undefined> => {
   // Create output dir
   if (outputPath) {
     mkdirp.sync(outputPathType === Output.File ? path.parse(outputPath).dir : outputPath);
   }
 
-  const unwrappedDocumentsArray = await unwrapIndividualDocuments(inputPath, outputPath, outputPathType);
-
-  return unwrappedDocumentsArray;
+  return await unwrapIndividualDocuments(inputPath, outputPath, outputPathType);
 };

--- a/src/implementations/unwrap/unwrap.ts
+++ b/src/implementations/unwrap/unwrap.ts
@@ -1,9 +1,4 @@
-import {
-  documentsInDirectory,
-  readOpenAttestationFile,
-  writeDocumentToDisk,
-  printDocumentToConsole,
-} from "../utils/disk";
+import { documentsInDirectory, readOpenAttestationFile, writeOutput } from "../utils/disk";
 import mkdirp from "mkdirp";
 import { getData, OpenAttestationDocument } from "@govtechsg/open-attestation";
 import path from "path";
@@ -30,7 +25,7 @@ export const unwrapIndividualDocuments = async (
       // Write unwrapped document to new directory
       writeOutput({
         outputPathType,
-        unwrappedDocumentPath: unwrappedDocumentDir,
+        documentPath: unwrappedDocumentDir,
         file,
         document: unwrappedDocument,
       });
@@ -39,26 +34,6 @@ export const unwrapIndividualDocuments = async (
     }
   }
   return oaArray.length;
-};
-
-const writeOutput = ({
-  outputPathType,
-  unwrappedDocumentPath,
-  file,
-  document,
-}: {
-  outputPathType: Output;
-  unwrappedDocumentPath?: string;
-  file: string;
-  document: any;
-}): void => {
-  if (outputPathType === Output.File && unwrappedDocumentPath) {
-    writeDocumentToDisk(path.parse(unwrappedDocumentPath).dir, path.parse(unwrappedDocumentPath).base, document);
-  } else if (outputPathType === Output.Directory && unwrappedDocumentPath) {
-    writeDocumentToDisk(unwrappedDocumentPath, path.parse(file).base, document);
-  } else {
-    printDocumentToConsole(document); // print to console, no file created
-  }
 };
 
 interface UnwrapArguments {

--- a/src/implementations/unwrap/unwrap.ts
+++ b/src/implementations/unwrap/unwrap.ts
@@ -1,21 +1,7 @@
 import { documentsInDirectory, readOpenAttestationFile, writeDocumentToDisk } from "../utils/disk";
-import { dirSync } from "tmp";
 import mkdirp from "mkdirp";
-import { getData, SchemaId, OpenAttestationDocument } from "@govtechsg/open-attestation";
+import { getData, OpenAttestationDocument } from "@govtechsg/open-attestation";
 import path from "path";
-import fetch from "node-fetch";
-import Ajv, { AnySchemaObject, ErrorObject, ValidateFunction } from "ajv";
-import addFormats from "ajv-formats";
-
-class SchemaValidationError extends Error {
-  constructor(message: string, public validationErrors: ErrorObject[], public document: any) {
-    super(message);
-  }
-}
-
-interface Schema {
-  $id: string;
-}
 
 export enum Output {
   File,
@@ -23,54 +9,23 @@ export enum Output {
   StdOut,
 }
 
-const remoteLoadSchema = async (uri: string): Promise<AnySchemaObject> => {
-  const response = await fetch(uri);
-  console.log({ uri });
-  const r = await response.json();
-  console.log({ uri });
-  return r;
-};
-
-const ajv = new Ajv({ loadSchema: remoteLoadSchema, allowUnionTypes: true });
-addFormats(ajv);
-ajv.addKeyword("deprecationMessage");
-
 export const unwrapIndividualDocuments = async (
-  undigestedDocumentPath: string,
-  digestedDocumentDir: string | undefined,
-  version: SchemaId,
-  unwrap: boolean,
-  outputPathType: Output,
-  schema?: Schema
+  wrappedDocumentPath: string,
+  unwrappedDocumentDir: string | undefined,
+  outputPathType: Output
 ): Promise<OpenAttestationDocument[]> => {
   const oaArray: OpenAttestationDocument[] = [];
-  const documentFileNames = await documentsInDirectory(undigestedDocumentPath);
-  let compile: ValidateFunction | undefined;
-  if (schema) {
-    compile = await ajv.compileAsync(schema);
-  }
+  const documentFileNames = await documentsInDirectory(wrappedDocumentPath);
 
   for (const file of documentFileNames) {
     const unwrappedDocument = getData(readOpenAttestationFile(file));
     oaArray.push(unwrappedDocument);
 
-    // Digest individual document
-    if (compile) {
-      const valid = compile(document);
-      if (!valid) {
-        throw new SchemaValidationError(
-          `Document ${path.resolve(file)} is not valid against the provided schema`,
-          compile.errors ?? [],
-          document
-        );
-      }
-    }
-
     try {
-      // Write digested document to new directory
+      // Write unwrapped document to new directory
       writeOutput({
         outputPathType,
-        digestedDocumentPath: digestedDocumentDir,
+        unwrappedDocumentPath: unwrappedDocumentDir,
         file,
         document: unwrappedDocument,
       });
@@ -83,61 +38,33 @@ export const unwrapIndividualDocuments = async (
 
 const writeOutput = ({
   outputPathType,
-  digestedDocumentPath,
+  unwrappedDocumentPath,
   file,
   document,
 }: {
   outputPathType: Output;
-  digestedDocumentPath?: string;
+  unwrappedDocumentPath?: string;
   file: string;
   document: any;
 }): void => {
-  if (outputPathType === Output.File && digestedDocumentPath) {
-    writeDocumentToDisk(path.parse(digestedDocumentPath).dir, path.parse(digestedDocumentPath).base, document);
-  } else if (outputPathType === Output.Directory && digestedDocumentPath) {
-    writeDocumentToDisk(digestedDocumentPath, path.parse(file).base, document);
+  if (outputPathType === Output.File && unwrappedDocumentPath) {
+    writeDocumentToDisk(path.parse(unwrappedDocumentPath).dir, path.parse(unwrappedDocumentPath).base, document);
+  } else if (outputPathType === Output.Directory && unwrappedDocumentPath) {
+    writeDocumentToDisk(unwrappedDocumentPath, path.parse(file).base, document);
   } else {
     console.log(JSON.stringify(document, undefined, 2)); // print to console, no file created
   }
 };
 
-const loadSchema = (schemaPath?: string): Promise<Schema | undefined> => {
-  const checkSchema = (schema: any): Schema => {
-    if (!schema.$id) {
-      throw new Error("Invalid schema, you must provide an $id property to your schema");
-    }
-    return schema;
-  };
-  if (schemaPath && (schemaPath.startsWith("http://") || schemaPath.startsWith("https://"))) {
-    return fetch(schemaPath)
-      .then((response) => response.json())
-      .then(checkSchema);
-  } else if (schemaPath) {
-    return import(path.resolve(schemaPath)).then(checkSchema);
-  }
-  return Promise.resolve(undefined);
-};
-
 interface UnwrapArguments {
   inputPath: string;
   outputPath?: string;
-  schemaPath?: string;
-  version: SchemaId;
-  unwrap: boolean;
-  batched: boolean;
   outputPathType: Output;
-  dnsTxt?: string;
-  documentStore?: string;
-  templateUrl?: string;
 }
 
 export const unwrap = async ({
   inputPath,
   outputPath,
-  schemaPath,
-  version,
-  unwrap,
-  batched,
   outputPathType,
 }: UnwrapArguments): Promise<OpenAttestationDocument[] | undefined> => {
   // Create output dir
@@ -145,24 +72,7 @@ export const unwrap = async ({
     mkdirp.sync(outputPathType === Output.File ? path.parse(outputPath).dir : outputPath);
   }
 
-  // Create intermediate dir
-  const { name: intermediateDir, removeCallback } = dirSync({
-    unsafeCleanup: true,
-  });
+  const unwrappedDocumentsArray = await unwrapIndividualDocuments(inputPath, outputPath, outputPathType);
 
-  // Phase 1: For each document, read content, digest and write to file
-  const schema = await loadSchema(schemaPath);
-  const rawDocumentsArray = await unwrapIndividualDocuments(
-    inputPath,
-    // if we dont batch document we can directly write to the destination folder. Otherwise we need to output in a temporary folder to compute the merkle root later
-    batched ? intermediateDir : outputPath,
-    version,
-    unwrap,
-    batched ? Output.Directory : outputPathType,
-    schema
-  );
-
-  // Remove intermediate dir
-  removeCallback();
-  return rawDocumentsArray;
+  return unwrappedDocumentsArray;
 };

--- a/src/implementations/utils/disk.ts
+++ b/src/implementations/utils/disk.ts
@@ -39,7 +39,7 @@ export const writeDocumentToDisk = (destinationDir: string, filename: string, do
   fs.writeFileSync(path.join(path.resolve(destinationDir), filename), JSON.stringify(document, null, 2));
 };
 
-enum Output {
+export enum Output {
   File,
   Directory,
   StdOut,

--- a/src/implementations/utils/disk.ts
+++ b/src/implementations/utils/disk.ts
@@ -39,6 +39,7 @@ export const writeDocumentToDisk = (destinationDir: string, filename: string, do
   fs.writeFileSync(path.join(path.resolve(destinationDir), filename), JSON.stringify(document, null, 2));
 };
 
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const printDocumentToConsole = (document: any): void => {
   console.log(JSON.stringify(document, undefined, 2));
 };

--- a/src/implementations/utils/disk.ts
+++ b/src/implementations/utils/disk.ts
@@ -38,3 +38,7 @@ export const documentsInDirectory = async (documentPath: string): Promise<string
 export const writeDocumentToDisk = (destinationDir: string, filename: string, document: any): void => {
   fs.writeFileSync(path.join(path.resolve(destinationDir), filename), JSON.stringify(document, null, 2));
 };
+
+export const printDocumentToConsole = (document: any): void => {
+  console.log(JSON.stringify(document, undefined, 2));
+};

--- a/src/implementations/utils/disk.ts
+++ b/src/implementations/utils/disk.ts
@@ -39,7 +39,28 @@ export const writeDocumentToDisk = (destinationDir: string, filename: string, do
   fs.writeFileSync(path.join(path.resolve(destinationDir), filename), JSON.stringify(document, null, 2));
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const printDocumentToConsole = (document: any): void => {
-  console.log(JSON.stringify(document, undefined, 2));
+enum Output {
+  File,
+  Directory,
+  StdOut,
+}
+
+export const writeOutput = ({
+  outputPathType,
+  documentPath,
+  file,
+  document,
+}: {
+  outputPathType: Output;
+  documentPath?: string;
+  file: string;
+  document: any;
+}): void => {
+  if (outputPathType === Output.File && documentPath) {
+    writeDocumentToDisk(path.parse(documentPath).dir, path.parse(documentPath).base, document);
+  } else if (outputPathType === Output.Directory && documentPath) {
+    writeDocumentToDisk(documentPath, path.parse(file).base, document);
+  } else {
+    console.log(JSON.stringify(document, undefined, 2)); // print to console, no file created
+  }
 };

--- a/src/implementations/wrap/wrap.ts
+++ b/src/implementations/wrap/wrap.ts
@@ -1,9 +1,4 @@
-import {
-  documentsInDirectory,
-  readOpenAttestationFile,
-  writeDocumentToDisk,
-  printDocumentToConsole,
-} from "../utils/disk";
+import { documentsInDirectory, readOpenAttestationFile, writeOutput } from "../utils/disk";
 import { dirSync } from "tmp";
 import mkdirp from "mkdirp";
 import {
@@ -129,7 +124,7 @@ export const wrapIndividualDocuments = async (
       // Write digested document to new directory
       writeOutput({
         outputPathType,
-        digestedDocumentPath: digestedDocumentDir,
+        documentPath: digestedDocumentDir,
         file,
         document: wrappedDocument,
       });
@@ -146,27 +141,6 @@ export const wrapIndividualDocuments = async (
   }
   return hashArray;
 };
-
-const writeOutput = ({
-  outputPathType,
-  digestedDocumentPath,
-  file,
-  document,
-}: {
-  outputPathType: Output;
-  digestedDocumentPath?: string;
-  file: string;
-  document: any;
-}): void => {
-  if (outputPathType === Output.File && digestedDocumentPath) {
-    writeDocumentToDisk(path.parse(digestedDocumentPath).dir, path.parse(digestedDocumentPath).base, document);
-  } else if (outputPathType === Output.Directory && digestedDocumentPath) {
-    writeDocumentToDisk(digestedDocumentPath, path.parse(file).base, document);
-  } else {
-    printDocumentToConsole(document); // print to console, no file created
-  }
-};
-
 export const appendProofToDocuments = async ({
   intermediateDir,
   hashMap,
@@ -197,7 +171,7 @@ export const appendProofToDocuments = async ({
     document.signature ? (document.signature.merkleRoot = candidateRoot) : (document.proof.merkleRoot = candidateRoot);
     if (!merkleRoot) merkleRoot = candidateRoot;
 
-    writeOutput({ outputPathType, digestedDocumentPath, file, document });
+    writeOutput({ outputPathType, documentPath: digestedDocumentPath, file, document });
   });
 
   return merkleRoot;

--- a/src/implementations/wrap/wrap.ts
+++ b/src/implementations/wrap/wrap.ts
@@ -1,4 +1,9 @@
-import { documentsInDirectory, readOpenAttestationFile, writeDocumentToDisk } from "../utils/disk";
+import {
+  documentsInDirectory,
+  readOpenAttestationFile,
+  writeDocumentToDisk,
+  printDocumentToConsole,
+} from "../utils/disk";
 import { dirSync } from "tmp";
 import mkdirp from "mkdirp";
 import {
@@ -158,7 +163,7 @@ const writeOutput = ({
   } else if (outputPathType === Output.Directory && digestedDocumentPath) {
     writeDocumentToDisk(digestedDocumentPath, path.parse(file).base, document);
   } else {
-    console.log(JSON.stringify(document, undefined, 2)); // print to console, no file created
+    printDocumentToConsole(document); // print to console, no file created
   }
 };
 

--- a/src/implementations/wrap/wrap.ts
+++ b/src/implementations/wrap/wrap.ts
@@ -1,4 +1,4 @@
-import { documentsInDirectory, readOpenAttestationFile, writeOutput } from "../utils/disk";
+import { documentsInDirectory, readOpenAttestationFile, writeOutput, Output } from "../utils/disk";
 import { dirSync } from "tmp";
 import mkdirp from "mkdirp";
 import {
@@ -23,12 +23,6 @@ class SchemaValidationError extends Error {
 
 interface Schema {
   $id: string;
-}
-
-export enum Output {
-  File,
-  Directory,
-  StdOut,
 }
 
 const remoteLoadSchema = async (uri: string): Promise<AnySchemaObject> => {


### PR DESCRIPTION
**Context**
To support unwrapping of a single wrapped document in the OA CLI

**What does this PR do?**
Supports the command below to take in a single wrapped document and unwrap it to a specified folder output. 

Command - `npm run dev -- unwrap <wrapped-document-file> --output-file <output-document-file>`