### PR TITLE
test: update networks used from ropsten to goerli

### DIFF
--- a/src/__tests__/verify.v2.e2e.test.ts
+++ b/src/__tests__/verify.v2.e2e.test.ts
@@ -12,7 +12,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v2", "signed-documents", "did.json"),
       verbose: true,
-      network: "ropsten",
+      network: "goerli",
     });
     expect(signaleSuccessSpy).toHaveBeenCalledTimes(4);
     expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "The document is valid");
@@ -24,7 +24,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v2", "signed-documents", "dnsDid.json"),
       verbose: true,
-      network: "ropsten",
+      network: "goerli",
     });
     expect(signaleSuccessSpy).toHaveBeenCalledTimes(4);
     expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "The document is valid");
@@ -37,7 +37,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v2", "signed-documents", "did-invalid.json"),
       verbose: true,
-      network: "ropsten",
+      network: "goerli",
     });
     expect(signaleErrorSpy).toHaveBeenCalledTimes(4);
     expect(signaleErrorSpy).toHaveBeenNthCalledWith(1, "The document is not valid");

--- a/src/__tests__/verify.v3.e2e.test.ts
+++ b/src/__tests__/verify.v3.e2e.test.ts
@@ -12,7 +12,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v3", "signed-documents", "dnsdid-invalid-v3.json"),
       verbose: true,
-      network: "ropsten",
+      network: "goerli",
     });
     expect(signaleSuccessSpy).toHaveBeenCalledTimes(2);
     expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "The document has not been tampered");
@@ -25,7 +25,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v3", "signed-documents", "did-v3.json"),
       verbose: true,
-      network: "ropsten",
+      network: "goerli",
     });
     expect(signaleSuccessSpy).toHaveBeenCalledTimes(4);
     expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "The document is valid");

--- a/src/implementations/config/helpers.ts
+++ b/src/implementations/config/helpers.ts
@@ -89,7 +89,7 @@ export const getTokenRegistryAddress = async (encryptedWalletPath: string): Prom
   info(`Enter password to continue deployment of Token Registry`);
   const tokenRegistry = await deployTokenRegistry({
     encryptedWalletPath,
-    network: "ropsten",
+    network: "goerli",
     gasPriceScale: 1,
     dryRun: false,
     registryName: "Token Registry",
@@ -104,7 +104,7 @@ export const getDocumentStoreAddress = async (encryptedWalletPath: string): Prom
   info(`Enter password to continue deployment of Document Store`);
   const documentStore = await deployDocumentStore({
     encryptedWalletPath,
-    network: "ropsten",
+    network: "goerli",
     gasPriceScale: 1,
     dryRun: false,
     storeName: "Document Store",

--- a/src/implementations/deploy/document-store/document-store.test.ts
+++ b/src/implementations/deploy/document-store/document-store.test.ts
@@ -8,7 +8,7 @@ jest.mock("@govtechsg/document-store");
 
 const deployParams: DeployDocumentStoreCommand = {
   storeName: "Test Document Store",
-  network: "ropsten",
+  network: "goerli",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
   dryRun: false,
@@ -36,7 +36,7 @@ describe("document-store", () => {
 
       await deployDocumentStore({
         storeName: "Test",
-        network: "ropsten",
+        network: "goerli",
         gasPriceScale: 1,
         dryRun: false,
       });
@@ -48,7 +48,7 @@ describe("document-store", () => {
     it("should take in the key from key file", async () => {
       await deployDocumentStore({
         storeName: "Test",
-        network: "ropsten",
+        network: "goerli",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
         dryRun: false,
@@ -79,7 +79,7 @@ describe("document-store", () => {
       await expect(
         deployDocumentStore({
           storeName: "Test",
-          network: "ropsten",
+          network: "goerli",
           gasPriceScale: 1,
           dryRun: false,
         })

--- a/src/implementations/deploy/title-escrow-creator/title-escrow-creator.test.ts
+++ b/src/implementations/deploy/title-escrow-creator/title-escrow-creator.test.ts
@@ -7,7 +7,7 @@ import { DeployTitleEscrowCreatorCommand } from "../../../commands/deploy/deploy
 jest.mock("@govtechsg/token-registry");
 
 const deployParams: DeployTitleEscrowCreatorCommand = {
-  network: "ropsten",
+  network: "goerli",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
   dryRun: false,
@@ -33,7 +33,7 @@ describe("token-registry", () => {
       process.env.OA_PRIVATE_KEY = "0000000000000000000000000000000000000000000000000000000000000002";
 
       await deployTitleEscrowCreator({
-        network: "ropsten",
+        network: "goerli",
         gasPriceScale: 1,
         dryRun: false,
       });
@@ -44,7 +44,7 @@ describe("token-registry", () => {
 
     it("should take in the key from key file", async () => {
       await deployTitleEscrowCreator({
-        network: "ropsten",
+        network: "goerli",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
         dryRun: false,
@@ -74,7 +74,7 @@ describe("token-registry", () => {
       delete process.env.OA_PRIVATE_KEY;
       await expect(
         deployTitleEscrowCreator({
-          network: "ropsten",
+          network: "goerli",
           gasPriceScale: 1,
           dryRun: false,
         })

--- a/src/implementations/deploy/title-escrow/title-escrow.test.ts
+++ b/src/implementations/deploy/title-escrow/title-escrow.test.ts
@@ -11,7 +11,7 @@ const deployParams: DeployTitleEscrowCommand = {
   beneficiary: "0x0000000000000000000000000000000000000001",
   holder: "0x0000000000000000000000000000000000000002",
   titleEscrowFactory: "0x0000000000000000000000000000000000000003",
-  network: "ropsten",
+  network: "goerli",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
   dryRun: false,
@@ -41,7 +41,7 @@ describe("token-registry", () => {
         beneficiary: "0x0000000000000000000000000000000000000001",
         holder: "0x0000000000000000000000000000000000000002",
         titleEscrowFactory: "0x0000000000000000000000000000000000000003",
-        network: "ropsten",
+        network: "goerli",
         gasPriceScale: 1,
         dryRun: false,
       });
@@ -52,7 +52,7 @@ describe("token-registry", () => {
 
     it("should take in the key from key file", async () => {
       await deployTitleEscrow({
-        network: "ropsten",
+        network: "goerli",
         tokenRegistry: "0x0000000000000000000000000000000000000000",
         beneficiary: "0x0000000000000000000000000000000000000001",
         holder: "0x0000000000000000000000000000000000000002",
@@ -90,7 +90,7 @@ describe("token-registry", () => {
       delete process.env.OA_PRIVATE_KEY;
       await expect(
         deployTitleEscrow({
-          network: "ropsten",
+          network: "goerli",
           tokenRegistry: "0x0000000000000000000000000000000000000000",
           beneficiary: "0x0000000000000000000000000000000000000001",
           holder: "0x0000000000000000000000000000000000000002",

--- a/src/implementations/deploy/token-registry/token-registry.test.ts
+++ b/src/implementations/deploy/token-registry/token-registry.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/token-registry");
 const deployParams: DeployTokenRegistryCommand = {
   registryName: "Test",
   registrySymbol: "Tst",
-  network: "ropsten",
+  network: "goerli",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
   dryRun: false,
@@ -37,7 +37,7 @@ describe("token-registry", () => {
       await deployTokenRegistry({
         registryName: "Test",
         registrySymbol: "Tst",
-        network: "ropsten",
+        network: "goerli",
         gasPriceScale: 1,
         dryRun: false,
       });
@@ -50,7 +50,7 @@ describe("token-registry", () => {
       await deployTokenRegistry({
         registryName: "Test",
         registrySymbol: "Tst",
-        network: "ropsten",
+        network: "goerli",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
         dryRun: false,
@@ -84,7 +84,7 @@ describe("token-registry", () => {
         deployTokenRegistry({
           registryName: "Test",
           registrySymbol: "Tst",
-          network: "ropsten",
+          network: "goerli",
           gasPriceScale: 1,
           dryRun: false,
         })

--- a/src/implementations/document-store/issue.test.ts
+++ b/src/implementations/document-store/issue.test.ts
@@ -10,7 +10,7 @@ jest.mock("@govtechsg/document-store");
 const deployParams: DocumentStoreIssueCommand = {
   hash: "0xabcd",
   address: "0x1234",
-  network: "ropsten",
+  network: "goerli",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
   dryRun: false,
@@ -52,7 +52,7 @@ describe("document-store", () => {
       await issueToDocumentStore({
         hash: "0xabcd",
         address: "0x1234",
-        network: "ropsten",
+        network: "goerli",
         gasPriceScale: 1,
         dryRun: false,
       });
@@ -65,7 +65,7 @@ describe("document-store", () => {
       await issueToDocumentStore({
         hash: "0xabcd",
         address: "0x1234",
-        network: "ropsten",
+        network: "goerli",
         keyFile: join(__dirname, "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
         dryRun: false,
@@ -111,7 +111,7 @@ describe("document-store", () => {
         issueToDocumentStore({
           hash: "0xabcd",
           address: "0x1234",
-          network: "ropsten",
+          network: "goerli",
           gasPriceScale: 1,
           dryRun: false,
         })

--- a/src/implementations/document-store/revoke.test.ts
+++ b/src/implementations/document-store/revoke.test.ts
@@ -10,7 +10,7 @@ jest.mock("@govtechsg/document-store");
 const deployParams: DocumentStoreRevokeCommand = {
   hash: "0xabcd",
   address: "0x1234",
-  network: "ropsten",
+  network: "goerli",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
   dryRun: false,
@@ -52,7 +52,7 @@ describe("document-store", () => {
       await revokeToDocumentStore({
         hash: "0xabcd",
         address: "0x1234",
-        network: "ropsten",
+        network: "goerli",
         gasPriceScale: 1,
         dryRun: false,
       });
@@ -65,7 +65,7 @@ describe("document-store", () => {
       await revokeToDocumentStore({
         hash: "0xabcd",
         address: "0x1234",
-        network: "ropsten",
+        network: "goerli",
         keyFile: join(__dirname, "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
         dryRun: false,
@@ -111,7 +111,7 @@ describe("document-store", () => {
         revokeToDocumentStore({
           hash: "0xabcd",
           address: "0x1234",
-          network: "ropsten",
+          network: "goerli",
           gasPriceScale: 1,
           dryRun: false,
         })

--- a/src/implementations/document-store/transfer-ownership.test.ts
+++ b/src/implementations/document-store/transfer-ownership.test.ts
@@ -10,7 +10,7 @@ jest.mock("@govtechsg/document-store");
 const deployParams: DocumentStoreTransferOwnershipCommand = {
   newOwner: "0xabcd",
   address: "0x1234",
-  network: "ropsten",
+  network: "goerli",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
   dryRun: false,
@@ -52,7 +52,7 @@ describe("document-store", () => {
       await transferDocumentStoreOwnershipToWallet({
         newOwner: "0xabcd",
         address: "0x1234",
-        network: "ropsten",
+        network: "goerli",
         gasPriceScale: 1,
         dryRun: false,
       });
@@ -65,7 +65,7 @@ describe("document-store", () => {
       await transferDocumentStoreOwnershipToWallet({
         newOwner: "0xabcd",
         address: "0x1234",
-        network: "ropsten",
+        network: "goerli",
         keyFile: join(__dirname, "..", "..", "..", "examples", "sample-key"),
         gasPriceScale: 1,
         dryRun: false,
@@ -114,7 +114,7 @@ describe("document-store", () => {
         transferDocumentStoreOwnershipToWallet({
           newOwner: "0xabcd",
           address: "0x1234",
-          network: "ropsten",
+          network: "goerli",
           gasPriceScale: 1,
           dryRun: false,
         })

--- a/src/implementations/title-escrow/acceptSurrendered.test.ts
+++ b/src/implementations/title-escrow/acceptSurrendered.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/token-registry");
 const acceptSurrenderedDocumentParams: TitleEscrowSurrenderDocumentCommand = {
   tokenRegistry: "0x1122",
   tokenId: "0x12345",
-  network: "ropsten",
+  network: "goerli",
   gasPriceScale: 1,
   dryRun: false,
 };

--- a/src/implementations/title-escrow/changeHolder.test.ts
+++ b/src/implementations/title-escrow/changeHolder.test.ts
@@ -10,7 +10,7 @@ const changeHolderParams: TitleEscrowChangeHolderCommand = {
   to: "0xabcd",
   tokenId: "0xzyxw",
   tokenRegistry: "0x1234",
-  network: "ropsten",
+  network: "goerli",
   gasPriceScale: 1,
   dryRun: false,
 };

--- a/src/implementations/title-escrow/endorseChangeOfOwner.test.ts
+++ b/src/implementations/title-escrow/endorseChangeOfOwner.test.ts
@@ -11,7 +11,7 @@ const endorseChangeOwnerParams: TitleEscrowEndorseChangeOfOwnerCommand = {
   newOwner: "0fosui",
   tokenId: "0xzyxw",
   tokenRegistry: "0x1234",
-  network: "ropsten",
+  network: "goerli",
   gasPriceScale: 1,
   dryRun: false,
 };

--- a/src/implementations/title-escrow/endorseTransferOfOwner.test.ts
+++ b/src/implementations/title-escrow/endorseTransferOfOwner.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/token-registry");
 const endorseTransferOfOwnerParams: TitleEscrowEndorseTransferOfOwnerCommand = {
   tokenId: "0xzyxw",
   tokenRegistry: "0x1234",
-  network: "ropsten",
+  network: "goerli",
   gasPriceScale: 1,
   dryRun: false,
 };

--- a/src/implementations/title-escrow/nominateChangeOfOwner.test.ts
+++ b/src/implementations/title-escrow/nominateChangeOfOwner.test.ts
@@ -10,7 +10,7 @@ const nominateChangeOfOwnerParams: TitleEscrowNominateChangeOfOwnerCommand = {
   newOwner: "0fosui",
   tokenId: "0xzyxw",
   tokenRegistry: "0x1234",
-  network: "ropsten",
+  network: "goerli",
   gasPriceScale: 1,
   dryRun: false,
 };

--- a/src/implementations/title-escrow/rejectSurrendered.test.ts
+++ b/src/implementations/title-escrow/rejectSurrendered.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/token-registry");
 const rejectSurrenderedDocumentParams: TitleEscrowSurrenderDocumentCommand = {
   tokenRegistry: "0x1122",
   tokenId: "0x12345",
-  network: "ropsten",
+  network: "goerli",
   gasPriceScale: 1,
   dryRun: false,
 };

--- a/src/implementations/title-escrow/surrenderDocument.test.ts
+++ b/src/implementations/title-escrow/surrenderDocument.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/token-registry");
 const surrenderDocumentParams: TitleEscrowSurrenderDocumentCommand = {
   tokenRegistry: "0x1122",
   tokenId: "0x12345",
-  network: "ropsten",
+  network: "goerli",
   gasPriceScale: 1,
   dryRun: false,
 };

--- a/src/implementations/token-registry/issue.test.ts
+++ b/src/implementations/token-registry/issue.test.ts
@@ -11,7 +11,7 @@ const deployParams: TokenRegistryIssueCommand = {
   to: "0xabcd",
   tokenId: "0xzyxw",
   address: "0x1234",
-  network: "ropsten",
+  network: "goerli",
   gasPriceScale: 1,
   dryRun: false,
 };

--- a/src/implementations/transaction/transaction.test.ts
+++ b/src/implementations/transaction/transaction.test.ts
@@ -28,7 +28,7 @@ describe("document-store", () => {
 
       await cancelTransaction({
         transactionHash: "0x456bba58226f03e3fb7d72b5143ceecfb6bfb66b00586929f6d60890ec264c2c",
-        network: "ropsten",
+        network: "goerli",
         keyFile: path.resolve(__dirname, "./key.file"),
       });
       expect(signaleInfoSpy).toHaveBeenNthCalledWith(1, "Transaction detail retrieved. Nonce: 10, Gas-price: 3");

--- a/src/implementations/utils/__tests__/wallet.test.ts
+++ b/src/implementations/utils/__tests__/wallet.test.ts
@@ -20,17 +20,17 @@ describe("wallet", () => {
   });
   it("should return the wallet when providing the key using environment variable", async () => {
     process.env.OA_PRIVATE_KEY = privateKey;
-    const wallet = await getWalletOrSigner({ network: "ropsten" });
+    const wallet = await getWalletOrSigner({ network: "goerli" });
     expect(await wallet.getAddress()).toStrictEqual(walletAddress);
     expect(wallet.privateKey).toStrictEqual(privateKey);
   });
   it("should return the wallet when providing the key using key option", async () => {
-    const wallet = await getWalletOrSigner({ network: "ropsten", key: privateKey });
+    const wallet = await getWalletOrSigner({ network: "goerli", key: privateKey });
     expect(await wallet.getAddress()).toStrictEqual(walletAddress);
     expect(wallet.privateKey).toStrictEqual(privateKey);
   });
   it("should return the wallet when providing the key using key-file option", async () => {
-    const wallet = await getWalletOrSigner({ network: "ropsten", keyFile: path.resolve(__dirname, "./key.file") });
+    const wallet = await getWalletOrSigner({ network: "goerli", keyFile: path.resolve(__dirname, "./key.file") });
     expect(await wallet.getAddress()).toStrictEqual(walletAddress);
     expect(wallet.privateKey).toStrictEqual(privateKey);
   });
@@ -38,7 +38,7 @@ describe("wallet", () => {
     promptMock.mockReturnValue({ password: "password123" });
 
     const wallet = await getWalletOrSigner({
-      network: "ropsten",
+      network: "goerli",
       encryptedWalletPath: path.resolve(__dirname, "./wallet.json"),
       progress: () => void 0, // shut up progress bar
     });
@@ -50,14 +50,14 @@ describe("wallet", () => {
 
     await expect(
       getWalletOrSigner({
-        network: "ropsten",
+        network: "goerli",
         encryptedWalletPath: path.resolve(__dirname, "./wallet.json"),
         progress: () => void 0, // shut up progress bar
       })
     ).rejects.toStrictEqual(new Error("invalid password"));
   });
   it("should throw an error when no option is provided", async () => {
-    await expect(getWalletOrSigner({ network: "ropsten" })).rejects.toStrictEqual(
+    await expect(getWalletOrSigner({ network: "goerli" })).rejects.toStrictEqual(
       new Error(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path, or provide aws kms signer information"
       )


### PR DESCRIPTION
## Summary

The tests are all breaking because they were connecting to Ropsten. This PR updates the network in the tests from Ropsten to Goerli.

## Changes

- Update all tests to use Goerli instead of Ropsten

## Issues

- https://www.pivotaltracker.com/story/show/183520197
