### PR TITLE
fix: bump doc store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1910,12 +1910,9 @@
       }
     },
     "@govtechsg/document-store": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@govtechsg/document-store/-/document-store-2.2.3.tgz",
-      "integrity": "sha512-d6D8ku4aCmdPaxHlU8OMwqIa0WHMZ02ZzUvYujlM/FInxTfKU1jUiAA4Jdx54D60hvhvGlBYU8T9jUsTZhBY4g==",
-      "requires": {
-        "lodash": "^4.17.21"
-      }
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@govtechsg/document-store/-/document-store-2.4.0.tgz",
+      "integrity": "sha512-kbQaFzPdrGs3ZH2bPq9reX4bR1vRaytLf6UsgrYzrJiI43vLVAW3h0seNmR5kvbeauclUJI+hofG47kdtBrS6A=="
     },
     "@govtechsg/jsonld": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "dependencies": {
     "@govtechsg/dnsprove": "^2.3.0",
-    "@govtechsg/document-store": "^2.2.3",
+    "@govtechsg/document-store": "^2.4.0",
     "@govtechsg/oa-encryption": "^1.3.3",
     "@govtechsg/oa-verify": "^7.11.0",
     "@govtechsg/open-attestation": "^6.4.1",

--- a/src/implementations/deploy/document-store/document-store.test.ts
+++ b/src/implementations/deploy/document-store/document-store.test.ts
@@ -66,7 +66,7 @@ describe("document-store", () => {
       expect(passedSigner.privateKey).toBe(`0x${deployParams.key}`);
       expect(mockedDeploy.mock.calls[0][0]).toStrictEqual(deployParams.storeName);
       // price should be any length string of digits
-      expect(mockedDeploy.mock.calls[0][1].gasPrice.toString()).toStrictEqual(expect.stringMatching(/\d+/));
+      expect(mockedDeploy.mock.calls[0][2].gasPrice.toString()).toStrictEqual(expect.stringMatching(/\d+/));
       expect(instance.contractAddress).toBe("contractAddress");
     });
 


### PR DESCRIPTION
## Summary

Bumps the document store to use v2.4.0 in CLI.

## Changes

- Bumps document store to v2.4.0
- Set deployer as the default owner

## Issues

- https://github.com/Open-Attestation/document-store/pull/122
