### PR TITLE
feat: document store owner option

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,10 @@ open-attestation deploy document-store "My Name" --network goerli
 
 ✔  success   Document store deployed at 0x4B127b8d5e53872d403ce43414afeb1db67B1842
 ```
+By default, the owner of the document store will be the deployer. You can specify a different owner using the `--owner` option:
+```bash 
+open-attestation deploy document-store "My Name" --owner 0x1234 --network goerli
+```
 
 #### Issue document to document store
 

--- a/src/commands/deploy/deploy.types.ts
+++ b/src/commands/deploy/deploy.types.ts
@@ -3,6 +3,7 @@ import { GasOption, NetworkAndWalletSignerOption } from "../shared";
 export type DeployDocumentStoreCommand = NetworkAndWalletSignerOption &
   GasOption & {
     storeName: string;
+    owner?: string;
   };
 
 export type DeployTokenRegistryCommand = NetworkAndWalletSignerOption &

--- a/src/commands/deploy/document-store.ts
+++ b/src/commands/deploy/document-store.ts
@@ -19,7 +19,12 @@ export const builder = (yargs: Argv): Argv =>
         description: "Name of the store",
         normalize: true,
       })
-    )
+    ).option("owner", {
+      alias: "o",
+      description: "Document Store owner address. Default owner is deployer address.",
+      type: "string",
+      normalize: true,
+    })
   );
 
 export const handler = async (args: DeployDocumentStoreCommand): Promise<string | undefined> => {

--- a/src/implementations/deploy/document-store/document-store.test.ts
+++ b/src/implementations/deploy/document-store/document-store.test.ts
@@ -8,6 +8,7 @@ jest.mock("@govtechsg/document-store");
 
 const deployParams: DeployDocumentStoreCommand = {
   storeName: "Test Document Store",
+  owner: "0x1234",
   network: "goerli",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   gasPriceScale: 1,
@@ -65,6 +66,7 @@ describe("document-store", () => {
 
       expect(passedSigner.privateKey).toBe(`0x${deployParams.key}`);
       expect(mockedDeploy.mock.calls[0][0]).toStrictEqual(deployParams.storeName);
+      expect(mockedDeploy.mock.calls[0][1]).toStrictEqual(deployParams.owner);
       // price should be any length string of digits
       expect(mockedDeploy.mock.calls[0][2].gasPrice.toString()).toStrictEqual(expect.stringMatching(/\d+/));
       expect(instance.contractAddress).toBe("contractAddress");
@@ -86,6 +88,21 @@ describe("document-store", () => {
       ).rejects.toThrow(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path, or provide aws kms signer information"
       );
+    });
+
+    it("should default the owner as the deployer", async () => {
+      process.env.OA_PRIVATE_KEY = "0000000000000000000000000000000000000000000000000000000000000002";
+
+      await deployDocumentStore({
+        storeName: "Test",
+        network: "goerli",
+        gasPriceScale: 1,
+        dryRun: false,
+      });
+
+      const passedSigner: Wallet = mockedDocumentStoreFactory.mock.calls[0][0];
+      const addr = await passedSigner.getAddress();
+      expect(mockedDeploy.mock.calls[0][1]).toStrictEqual(addr);
     });
   });
 });

--- a/src/implementations/deploy/document-store/document-store.ts
+++ b/src/implementations/deploy/document-store/document-store.ts
@@ -9,13 +9,14 @@ const { trace } = getLogger("deploy:document-store");
 
 export const deployDocumentStore = async ({
   storeName,
+  owner,
   network,
   gasPriceScale,
   dryRun,
   ...rest
 }: DeployDocumentStoreCommand): Promise<{ contractAddress: string }> => {
   const wallet = await getWalletOrSigner({ network, ...rest });
-  const ownerAddress = await wallet.getAddress();
+  const ownerAddress = owner ?? (await wallet.getAddress());
 
   if (dryRun) {
     await dryRunMode({


### PR DESCRIPTION
## Summary

Add an option for document store deployment to allow a deployer to specify a different owner than herself.

## Changes

- Add an optional `--owner` option to document-store deploy command
- Update tests
- Update readme doc

## Issues
- https://www.pivotaltracker.com/story/show/183880095
-  #237 
- https://github.com/Open-Attestation/document-store/pull/122
