### PR TITLE
feat: config other networks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ key
 /.vscode/
 /vc-test-suite
 .DS_Store
+
+# create config related
+wallet.json
+example-configs

--- a/README.md
+++ b/README.md
@@ -517,8 +517,8 @@ There are 2 ways of using this command to generate a config file, both in which,
 
 These are the reference config templates:
 
-- [v2 config template](https://raw.githubusercontent.com/TradeTrust/tradetrust-config/master/build/config-reference-v2.json)
-- [v3 config template](https://raw.githubusercontent.com/TradeTrust/tradetrust-config/master/build/config-reference-v3.json).
+- [v2 config template](https://raw.githubusercontent.com/TradeTrust/tradetrust-config/master/build/reference/config-v2.json)
+- [v3 config template](https://raw.githubusercontent.com/TradeTrust/tradetrust-config/master/build/reference/config-v3.json).
 
 Step 1: Generate a wallet.json file & add funds into wallet.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1999,20 +1999,20 @@
       "integrity": "sha512-0VIeANA2XpaMNBLBAImwXf3SMV9wQcQeU4HxRgPzWaG4X/MpS2Msxv6YyTwk++p+j57s3PNoUQC5JiIAaY7xZw=="
     },
     "@govtechsg/tradetrust-config": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@govtechsg/tradetrust-config/-/tradetrust-config-1.2.2.tgz",
-      "integrity": "sha512-qxe+NgChvkB1RJAB5Ln8dxBLJGYXWthdG8Qb2Qeq8EI2QBjVjaJ0whqridEDWMYJlwDw6zJymKtwg+6Td3yWRw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@govtechsg/tradetrust-config/-/tradetrust-config-1.2.3.tgz",
+      "integrity": "sha512-5TYsvr/Htaf/tli9Zj3/DtSsdAXOhI6jg+RMjmbwp4eaKnovnGUWzvcbPcOvz05SO6nQTTP9aJut3lN4+qrfKg==",
       "requires": {
-        "ajv": "^8.8.2",
+        "ajv": "^8.11.2",
         "ajv-formats": "^2.1.1",
         "junk": "3.1.0",
-        "typedoc": "^0.22.10"
+        "typedoc": "^0.23.23"
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-          "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -14254,13 +14254,13 @@
       "optional": true
     },
     "shiki": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
-      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.12.1.tgz",
+      "integrity": "sha512-aieaV1m349rZINEBkjxh2QbBvFFQOlgqYTNtCal82hHj4dDZ76oMlQIX+C7ryerBTDiga3e5NfH6smjdJ02BbQ==",
       "requires": {
-        "jsonc-parser": "^3.0.0",
-        "vscode-oniguruma": "^1.6.1",
-        "vscode-textmate": "5.2.0"
+        "jsonc-parser": "^3.2.0",
+        "vscode-oniguruma": "^1.7.0",
+        "vscode-textmate": "^8.0.0"
       }
     },
     "signal-exit": {
@@ -16183,15 +16183,14 @@
       }
     },
     "typedoc": {
-      "version": "0.22.18",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
-      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
+      "version": "0.23.24",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.24.tgz",
+      "integrity": "sha512-bfmy8lNQh+WrPYcJbtjQ6JEEsVl/ce1ZIXyXhyW+a1vFrjO39t6J8sL/d6FfAGrJTc7McCXgk9AanYBSNvLdIA==",
       "requires": {
-        "glob": "^8.0.3",
         "lunr": "^2.3.9",
-        "marked": "^4.0.16",
-        "minimatch": "^5.1.0",
-        "shiki": "^0.10.1"
+        "marked": "^4.2.5",
+        "minimatch": "^5.1.2",
+        "shiki": "^0.12.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -16200,18 +16199,6 @@
           "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
           "requires": {
             "balanced-match": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "8.0.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-8.0.3.tgz",
-          "integrity": "sha512-ull455NHSHI/Y1FqGaaYFaLGkNMMJbavMrEGFXG/PGrg6y7sutWHUHrz6gy6WEBH6akM1M414dWKCNs+IhKdiQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^5.0.1",
-            "once": "^1.3.0"
           }
         },
         "marked": {
@@ -16730,9 +16717,9 @@
       "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA=="
     },
     "vscode-textmate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
-      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-8.0.0.tgz",
+      "integrity": "sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@govtechsg/oa-verify": "^7.11.0",
     "@govtechsg/open-attestation": "^6.4.1",
     "@govtechsg/token-registry": "^2.5.3",
-    "@govtechsg/tradetrust-config": "^1.2.2",
+    "@govtechsg/tradetrust-config": "^1.2.3",
     "ajv": "^8.4.0",
     "ajv-formats": "^2.1.0",
     "chalk": "^4.1.2",

--- a/src/commands/networks.ts
+++ b/src/commands/networks.ts
@@ -1,10 +1,13 @@
 import { providers } from "ethers";
 
+export type networkCurrency = "ETH" | "MATIC";
+
 type SupportedNetwork = {
   explorer: string;
   provider: () => providers.Provider;
   networkId: number;
   networkName: string;
+  currency: networkCurrency;
 };
 
 export enum NetworkCmdName {
@@ -12,8 +15,8 @@ export enum NetworkCmdName {
   Mainnet = "mainnet",
   Goerli = "goerli",
   Sepolia = "sepolia",
-  Polygon = "polygon",
-  Mumbai = "mumbai",
+  Matic = "matic",
+  Maticmum = "maticmum",
 }
 
 const defaultInfuraProvider =
@@ -34,36 +37,42 @@ export const supportedNetwork: {
     provider: jsonRpcProvider("http://127.0.0.1:8545"),
     networkId: 1337,
     networkName: "local",
+    currency: "ETH",
   },
   [NetworkCmdName.Mainnet]: {
     explorer: "https://etherscan.io",
     provider: defaultInfuraProvider("homestead"),
     networkId: 1,
     networkName: "homestead",
+    currency: "ETH",
   },
   [NetworkCmdName.Goerli]: {
     explorer: "https://goerli.etherscan.io",
     provider: defaultInfuraProvider("goerli"),
     networkId: 5,
     networkName: "goerli",
+    currency: "ETH",
   },
   [NetworkCmdName.Sepolia]: {
     explorer: "https://sepolia.etherscan.io",
     provider: jsonRpcProvider("https://rpc.sepolia.org"),
     networkId: 11155111,
     networkName: "sepolia",
+    currency: "ETH",
   },
-  [NetworkCmdName.Polygon]: {
+  [NetworkCmdName.Matic]: {
     explorer: "https://polygonscan.com",
     provider: defaultInfuraProvider("matic"),
     networkId: 137,
     networkName: "matic",
+    currency: "MATIC",
   },
-  [NetworkCmdName.Mumbai]: {
+  [NetworkCmdName.Maticmum]: {
     explorer: "https://mumbai.polygonscan.com",
     provider: defaultInfuraProvider("maticmum"),
     networkId: 80001,
     networkName: "maticmum",
+    currency: "MATIC",
   },
 };
 

--- a/src/implementations/config/__tests__/create.test.ts
+++ b/src/implementations/config/__tests__/create.test.ts
@@ -7,7 +7,7 @@ import { NetworkCmdName } from "../../../commands/networks";
 import { deployDocumentStore } from "../../deploy/document-store/document-store";
 import { deployTokenRegistry } from "../../deploy/token-registry/token-registry";
 import { create as createConfig } from "../create";
-import expectedConfigFileOutput from "./expected-config-file-output.json";
+import expectedConfigFileOutput from "./expected-config-file-output-v2.json";
 import inputConfigFile from "./input-config-file.json";
 
 const mockInputConfigFile = inputConfigFile;

--- a/src/implementations/config/__tests__/expected-config-file-output-v2.json
+++ b/src/implementations/config/__tests__/expected-config-file-output-v2.json
@@ -22,7 +22,11 @@
             "name": "DEMO TOKEN REGISTRY",
             "tokenRegistry": "0x620c1DC991E3E2585aFbaA61c762C0369D70C89D"
           }
-        ]
+        ],
+        "network": {
+          "chainId": "5",
+          "chain": "ETH"
+        }
       }
     },
     {
@@ -38,7 +42,11 @@
               "location": "alert-cyan-stoat.sandbox.openattestation.com"
             }
           }
-        ]
+        ],
+        "network": {
+          "chainId": "5",
+          "chain": "ETH"
+        }
       }
     },
     {
@@ -58,7 +66,11 @@
               "key": "did:ethr:0x709731d94d65b078496937655582401157c8a640#controller"
             }
           }
-        ]
+        ],
+        "network": {
+          "chainId": "5",
+          "chain": "ETH"
+        }
       }
     }
   ]

--- a/src/implementations/config/__tests__/expected-config-file-output-v3.json
+++ b/src/implementations/config/__tests__/expected-config-file-output-v3.json
@@ -45,6 +45,10 @@
           "id": "https://example.com",
           "name": "DEMO TOKEN REGISTRY",
           "type": "OpenAttestationIssuer"
+        },
+        "network": {
+          "chainId": "5",
+          "chain": "ETH"
         }
       },
       "schema": {
@@ -180,6 +184,10 @@
           "id": "https://example.com",
           "name": "DEMO DOCUMENT STORE",
           "type": "OpenAttestationIssuer"
+        },
+        "network": {
+          "chainId": "5",
+          "chain": "ETH"
         }
       },
       "schema": {
@@ -645,6 +653,10 @@
           "id": "https://example.com",
           "name": "DEMO DNS-DID",
           "type": "OpenAttestationIssuer"
+        },
+        "network": {
+          "chainId": "5",
+          "chain": "ETH"
         }
       },
       "schema": {
@@ -819,6 +831,10 @@
           "id": "https://example.com",
           "name": "DEMO DOCUMENT STORE",
           "type": "OpenAttestationIssuer"
+        },
+        "network": {
+          "chainId": "5",
+          "chain": "ETH"
         }
       },
       "schema": {

--- a/src/implementations/config/__tests__/helpers.test.ts
+++ b/src/implementations/config/__tests__/helpers.test.ts
@@ -1,4 +1,11 @@
-import { getConfigFile, getConfigWithUpdatedForms } from "../helpers";
+import { NetworkCmdName } from "../../../commands/networks";
+import {
+  getConfigFile,
+  getConfigWithUpdatedForms,
+  getConfigWithUpdatedNetwork,
+  getConfigWithUpdatedWallet,
+} from "../helpers";
+import { ConfigFile } from "../types";
 import ConfigFileV3 from "./config-reference-v3.json";
 import expectedConfigFileOutputV3 from "./expected-config-file-output-v3.json";
 import expectedConfigFileOutputV2 from "./expected-config-file-output-v2.json";
@@ -19,17 +26,43 @@ describe("getConfigFile", () => {
     await expect(getConfigFile("", "")).rejects.toHaveProperty("message", "Config template reference not provided.");
   });
 });
-wallet;
+
+describe("getConfigWithUpdatedNetwork", () => {
+  it("should update config file with network for V2", () => {
+    expect(
+      getConfigWithUpdatedNetwork({ configFile: ConfigFileV2 as ConfigFile, network: NetworkCmdName.Goerli }).network
+    ).toStrictEqual(NetworkCmdName.Goerli);
+  });
+  it("should update config file with network for V3", () => {
+    expect(
+      getConfigWithUpdatedNetwork({ configFile: ConfigFileV3 as ConfigFile, network: NetworkCmdName.Goerli }).network
+    ).toStrictEqual(NetworkCmdName.Goerli);
+  });
+});
+
+describe("getConfigWithUpdatedWallet", () => {
+  it("should update config file with wallet string for V2", () => {
+    expect(
+      getConfigWithUpdatedWallet({ configFile: ConfigFileV2 as ConfigFile, walletStr: JSON.stringify(wallet) }).wallet
+        .encryptedJson
+    ).toStrictEqual(JSON.stringify(wallet));
+  });
+  it("should update config file with wallet string for V3", () => {
+    expect(
+      getConfigWithUpdatedWallet({ configFile: ConfigFileV3 as ConfigFile, walletStr: JSON.stringify(wallet) }).wallet
+        .encryptedJson
+    ).toStrictEqual(JSON.stringify(wallet));
+  });
+});
+
 describe("getConfigWithUpdatedForms", () => {
   it("should update form correctly for V2 forms", () => {
+    const configWithWallet = getConfigWithUpdatedWallet({
+      configFile: ConfigFileV2 as ConfigFile,
+      walletStr: JSON.stringify(wallet),
+    });
     const config = getConfigWithUpdatedForms({
-      configFile: {
-        ...ConfigFileV2,
-        wallet: {
-          ...ConfigFileV2.wallet,
-          encryptedJson: JSON.stringify(wallet),
-        },
-      } as any,
+      configFile: configWithWallet as ConfigFile,
       chain: {
         id: "5",
         currency: "ETH",
@@ -44,14 +77,12 @@ describe("getConfigWithUpdatedForms", () => {
   });
 
   it("should update form correctly for V3 forms", () => {
+    const configWithWallet = getConfigWithUpdatedWallet({
+      configFile: ConfigFileV3 as ConfigFile,
+      walletStr: JSON.stringify(wallet),
+    });
     const config = getConfigWithUpdatedForms({
-      configFile: {
-        ...ConfigFileV3,
-        wallet: {
-          ...ConfigFileV3.wallet,
-          encryptedJson: JSON.stringify(wallet),
-        },
-      } as any,
+      configFile: configWithWallet as ConfigFile,
       chain: {
         id: "5",
         currency: "ETH",

--- a/src/implementations/config/__tests__/helpers.test.ts
+++ b/src/implementations/config/__tests__/helpers.test.ts
@@ -1,15 +1,7 @@
-import { NetworkCmdName } from "../../../commands/networks";
-import {
-  getConfigFile,
-  getConfigWithUpdatedDocumentStorage,
-  getConfigWithUpdatedForms,
-  getConfigWithUpdatedNetwork,
-  getConfigWithUpdatedWallet,
-} from "../helpers";
-import { ConfigFile } from "../types";
+import { getConfigFile, getConfigWithUpdatedForms } from "../helpers";
 import ConfigFileV3 from "./config-reference-v3.json";
 import expectedConfigFileOutputV3 from "./expected-config-file-output-v3.json";
-import expectedConfigFileOutputV2 from "./expected-config-file-output.json";
+import expectedConfigFileOutputV2 from "./expected-config-file-output-v2.json";
 import ConfigFileV2 from "./input-config-file.json";
 import wallet from "./wallet.json";
 
@@ -17,7 +9,7 @@ describe("getConfigFile", () => {
   it("should return the config file when given a configTemplateUrl", async () => {
     const config = await getConfigFile(
       "",
-      "https://raw.githubusercontent.com/TradeTrust/tradetrust-config/master/build/config-reference-v3.json"
+      "https://raw.githubusercontent.com/TradeTrust/tradetrust-config/master/build/reference/config-v3.json"
     );
 
     expect(config).toStrictEqual(ConfigFileV3);
@@ -27,88 +19,21 @@ describe("getConfigFile", () => {
     await expect(getConfigFile("", "")).rejects.toHaveProperty("message", "Config template reference not provided.");
   });
 });
-
-describe("getConfigWithUpdatedNetwork", () => {
-  it("should update config file with network for V2", () => {
-    expect(
-      getConfigWithUpdatedNetwork({ configFile: ConfigFileV2 as ConfigFile, network: NetworkCmdName.Goerli }).network
-    ).toStrictEqual(NetworkCmdName.Goerli);
-  });
-  it("should update config file with network for V3", () => {
-    expect(
-      getConfigWithUpdatedNetwork({ configFile: ConfigFileV3 as ConfigFile, network: NetworkCmdName.Goerli }).network
-    ).toStrictEqual(NetworkCmdName.Goerli);
-  });
-});
-
-describe("getConfigWithUpdatedDocumentStorage", () => {
-  it("should remove document storage in the config file if network is not 'goerli' for V2", () => {
-    const config = { ...ConfigFileV2 };
-    expect(
-      getConfigWithUpdatedDocumentStorage({ configFile: config as ConfigFile, network: NetworkCmdName.Sepolia })
-        .documentStorage
-    ).toBeUndefined();
-  });
-
-  it("should remove document storage in the config file if network is not 'goerli' for V3", () => {
-    const config = { ...ConfigFileV3 };
-    expect(
-      getConfigWithUpdatedDocumentStorage({
-        configFile: config as ConfigFile,
-        network: NetworkCmdName.Sepolia,
-      }).documentStorage
-    ).toBeUndefined();
-  });
-
-  it("should not remove document storage in the config file if network is 'goerli' for V2", () => {
-    const config = { ...ConfigFileV2 };
-    expect(
-      getConfigWithUpdatedDocumentStorage({
-        configFile: config as ConfigFile,
-        network: NetworkCmdName.Goerli,
-      }).documentStorage
-    ).toStrictEqual({
-      apiKey: "randomKey",
-      url: "https://tradetrust-functions.netlify.app/.netlify/functions/storage",
-    });
-  });
-  it("should not remove document storage in the config file if network is 'goerli' for V3", () => {
-    const config = { ...ConfigFileV3 };
-    expect(
-      getConfigWithUpdatedDocumentStorage({
-        configFile: config as ConfigFile,
-        network: NetworkCmdName.Goerli,
-      }).documentStorage
-    ).toStrictEqual({
-      apiKey: "randomKey",
-      url: "https://tradetrust-functions.netlify.app/.netlify/functions/storage",
-    });
-  });
-});
-
-describe("getConfigWithUpdatedWallet", () => {
-  it("should update config file with wallet string for V2", () => {
-    expect(
-      getConfigWithUpdatedWallet({ configFile: ConfigFileV2 as ConfigFile, walletStr: JSON.stringify(wallet) }).wallet
-        .encryptedJson
-    ).toStrictEqual(JSON.stringify(wallet));
-  });
-  it("should update config file with wallet string for V3", () => {
-    expect(
-      getConfigWithUpdatedWallet({ configFile: ConfigFileV3 as ConfigFile, walletStr: JSON.stringify(wallet) }).wallet
-        .encryptedJson
-    ).toStrictEqual(JSON.stringify(wallet));
-  });
-});
-
+wallet;
 describe("getConfigWithUpdatedForms", () => {
   it("should update form correctly for V2 forms", () => {
-    const configWithWallet = getConfigWithUpdatedWallet({
-      configFile: ConfigFileV2 as ConfigFile,
-      walletStr: JSON.stringify(wallet),
-    });
     const config = getConfigWithUpdatedForms({
-      configFile: configWithWallet as ConfigFile,
+      configFile: {
+        ...ConfigFileV2,
+        wallet: {
+          ...ConfigFileV2.wallet,
+          encryptedJson: JSON.stringify(wallet),
+        },
+      } as any,
+      chain: {
+        id: "5",
+        currency: "ETH",
+      },
       documentStoreAddress: "0xC378aBE13cf18a64fB2f913647bd4Fe054C9eaEd",
       tokenRegistryAddress: "0x620c1DC991E3E2585aFbaA61c762C0369D70C89D",
       dnsVerifiable: "alert-cyan-stoat.sandbox.openattestation.com",
@@ -119,12 +44,18 @@ describe("getConfigWithUpdatedForms", () => {
   });
 
   it("should update form correctly for V3 forms", () => {
-    const configWithWallet = getConfigWithUpdatedWallet({
-      configFile: ConfigFileV3 as ConfigFile,
-      walletStr: JSON.stringify(wallet),
-    });
     const config = getConfigWithUpdatedForms({
-      configFile: configWithWallet as ConfigFile,
+      configFile: {
+        ...ConfigFileV3,
+        wallet: {
+          ...ConfigFileV3.wallet,
+          encryptedJson: JSON.stringify(wallet),
+        },
+      } as any,
+      chain: {
+        id: "5",
+        currency: "ETH",
+      },
       documentStoreAddress: "0xC378aBE13cf18a64fB2f913647bd4Fe054C9eaEd",
       tokenRegistryAddress: "0x620c1DC991E3E2585aFbaA61c762C0369D70C89D",
       dnsVerifiable: "alert-cyan-stoat.sandbox.openattestation.com",

--- a/src/implementations/config/create.ts
+++ b/src/implementations/config/create.ts
@@ -8,6 +8,8 @@ import { readFile } from "../utils/disk";
 import {
   getConfigFile,
   getConfigWithUpdatedForms,
+  getConfigWithUpdatedNetwork,
+  getConfigWithUpdatedWallet,
   getDocumentStoreAddress,
   getTokenRegistryAddress,
   validate,
@@ -97,16 +99,16 @@ export const create = async ({
     });
   }
 
-  // update config with user input arguments
-  const updatedConfigFile = {
-    ...configFile,
-    wallet: { ...configFile.wallet, encryptedJson: walletStr },
-    network,
-  };
+  const updatedConfigFileWithNetwork = getConfigWithUpdatedNetwork({ configFile, network });
+
+  const updatedConfigFileWithWallet = getConfigWithUpdatedWallet({
+    configFile: updatedConfigFileWithNetwork,
+    walletStr,
+  });
 
   // update config file with generated addresses + dns temp domain names
   const updatedConfigFileWithForms = getConfigWithUpdatedForms({
-    configFile: updatedConfigFile,
+    configFile: updatedConfigFileWithWallet,
     chain,
     documentStoreAddress,
     tokenRegistryAddress,

--- a/src/implementations/config/create.ts
+++ b/src/implementations/config/create.ts
@@ -106,7 +106,6 @@ export const create = async ({
     walletStr,
   });
 
-  // update config file with generated addresses + dns temp domain names
   const updatedConfigFileWithForms = getConfigWithUpdatedForms({
     configFile: updatedConfigFileWithWallet,
     chain,

--- a/src/implementations/config/helpers.ts
+++ b/src/implementations/config/helpers.ts
@@ -2,7 +2,7 @@ import { utils, v2, v3 } from "@govtechsg/open-attestation";
 import { updateFormV2, updateFormV3 } from "@govtechsg/tradetrust-config";
 import fetch from "node-fetch";
 import { success } from "signale";
-import { NetworkCmdName, networkCurrency } from "../../commands/networks";
+import { NetworkCmdName, supportedNetwork, networkCurrency } from "../../commands/networks";
 import { deployDocumentStore } from "../../implementations/deploy/document-store";
 import { deployTokenRegistry } from "../../implementations/deploy/token-registry";
 import { readFile } from "../../implementations/utils/disk";
@@ -10,6 +10,31 @@ import { highlight } from "../../utils";
 import { ConfigFile, Dns, Form } from "./types";
 import { Wallet } from "ethers";
 import { ConnectedSigner } from "../../implementations/utils/wallet";
+
+interface ConfigWithNetwork {
+  configFile: ConfigFile;
+  network: NetworkCmdName;
+}
+
+export const getConfigWithUpdatedNetwork = ({ configFile, network }: ConfigWithNetwork): ConfigFile => {
+  const networkName = supportedNetwork[network].networkName;
+  return {
+    ...configFile,
+    network: networkName,
+  };
+};
+
+interface UpdatedWallet {
+  configFile: ConfigFile;
+  walletStr: string;
+}
+
+export const getConfigWithUpdatedWallet = ({ configFile, walletStr }: UpdatedWallet): ConfigFile => {
+  return {
+    ...configFile,
+    wallet: { ...configFile.wallet, encryptedJson: walletStr },
+  };
+};
 
 interface UpdatedForms {
   configFile: ConfigFile;


### PR DESCRIPTION
## Summary

qr code not appearing for other networks, such as maticmum

## Changes

- `network` added in generated forms
- rename the networks to the correct names used on other tt applications
- remove conditional add `documentStorage`, field is now provided in tradetrust-config [reference config files](https://github.com/TradeTrust/tradetrust-config/blob/536d6f99a3783405540b32831c3dbcdcac0275a6/build/reference/config-v2.json#L7-L10) instead

## Issues

https://www.pivotaltracker.com/story/show/183929424
