### PR TITLE
fix: make wallet path optional

### DIFF
--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -90,7 +90,6 @@ export const withWalletOption = (yargs: Argv): Argv =>
     type: "string",
     description: "Path to wallet.json file",
     normalize: true,
-    demandOption: true,
   });
 
 export const withAwsKmsSignerOption = (yargs: Argv): Argv =>


### PR DESCRIPTION
## Summary
To revert `--encrypted-wallet-path` arg back to optional so that users can use `--key` or set their private key in their environment variable to be used 

## Changes
- Removed `demandOption: true` from `withWalletOption()` option
