### PR TITLE
feat: add aws session-token option to withAwsKmsSignerOption

### DIFF
--- a/src/commands/shared.ts
+++ b/src/commands/shared.ts
@@ -26,6 +26,7 @@ export type AwsKmsSignerOption = {
   secretAccessKey: string;
   region: string;
   kmsKeyId: string;
+  sessionToken: string;
 };
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -97,6 +98,11 @@ export const withAwsKmsSignerOption = (yargs: Argv): Argv =>
     .option("region", {
       type: "string",
       description: "AWS region. Example: us-east-2",
+    })
+    .option("session-token", {
+      type: "string",
+      description:
+        "AWS Session token. Example: IQoJb3JpZ2luX2VjEDsaDmFwLXNvdXRoZWFzdC0xIkcwRQIgR7ap3CSpkQ0U1IA1KYebxXB5pmpvHd59pTZRsmXzC5MCIQCij0GELbTj8R30Wcho1NgZq3q/dSLoFm2gD9WOFRxamiqeAggkEAMaDDczMzQ4NzYyMjk4MiIMiXeHIetiIMVm85SUKvsBTlIStOhlYNlNJmQHeiumoWXztNuksDK9/pEpam5ZALdi9TI6PJkSuAq+vd7c+ecMC7gN0Fs8sCkM5AjgG7x/WE+81tcOBq/oNF71drfViT5w7/mcBoElSEVUUjQx1oKWfcBLWD/tXu0593hPOi2dHdoG83/6KEgyaNrkpWQdTLK5zUTmtDYLsyoKwZEbGEulUK11WCfbCctJWtlk9RXHdDgbgDP2PzJpeuET4CV21GMX1jsnMeeRNhFX5dqy3+FMIjsAFiWGuE0Q7Fnyjrb/YQVG5BL3LqvYdJGI4HUT/fKtQrWS+skxCm1divsLAhl9+Z0GQ8WDgR3W4akwjt64oQY6nQFjnkWLSBf+OXpkWi1IzPPAqx09srAJiNmz8J+7kdHSLjr5IrKh1hzimxtVNkPX+22ahdmE5m4o5oJm1lgZSLmfYdmvifK76E8y247deFRl4Q0Z+75PDjriw1i4QJcg+USGcFJN6O/dOw5S4if/eYbPaoRBLQOAMYBYjr4aZ3TuMmMHNgMRLBKtQ8fVPpslU2L6XOPRkVR1RejSbII5",
     })
     .option("kms-key-id", {
       type: "string",

--- a/src/implementations/utils/wallet.ts
+++ b/src/implementations/utils/wallet.ts
@@ -60,7 +60,7 @@ export const getWalletOrSigner = async ({
       secretAccessKey: options.secretAccessKey, // credentials for your IAM user with KMS access
       region: options.region,
       keyId: options.kmsKeyId,
-      sessionToken: options.sessionToken
+      sessionToken: options.sessionToken,
     };
 
     const signer = new AwsKmsSigner(kmsCredentials).connect(provider);

--- a/src/implementations/utils/wallet.ts
+++ b/src/implementations/utils/wallet.ts
@@ -60,6 +60,7 @@ export const getWalletOrSigner = async ({
       secretAccessKey: options.secretAccessKey, // credentials for your IAM user with KMS access
       region: options.region,
       keyId: options.kmsKeyId,
+      sessionToken: options.sessionToken
     };
 
     const signer = new AwsKmsSigner(kmsCredentials).connect(provider);


### PR DESCRIPTION
## Summary

What is the background of this pull request?
My teams's access to aws also require a `SessionToken` to be included as part of the AWS credentials used.


## Changes

- Add `session-token` option to `withAwsKmsSignerOption`


## Issues

What are the related issues or stories?
