### PR TITLE
fix: update goerli deprecation and change to sepolia

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,13 @@ npx -p @govtechsg/open-attestation-cli open-attestation <arguments>
 
 ## Supported networks
 
-| Network | Chain ID | Type       |
-| ------- | -------- | ---------- |
-| mainnet | 1        | Production |
-| goerli  | 5        | Test       |
-| polygon | 137      | Production |
-| mumbai  | 80001    | Test       |
+| Network            | Chain ID | Type       |
+| ------------------ | -------- | ---------- |
+| mainnet            | 1        | Production |
+| sepolia            | 11155111 | Test       |
+| Goerli(Deprecated) | 5        | Test       |
+| polygon            | 137      | Production |
+| mumbai             | 80001    | Test       |
 
 ---
 
@@ -257,7 +258,7 @@ open-attestation deploy token-registry <registry-name> <registry-symbol> --facto
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation deploy token-registry "My Sample Token" MST --network goerli
+open-attestation deploy token-registry "My Sample Token" MST --network sepolia
 
 ✔  success   Token registry deployed at 0x4B127b8d5e53872d403ce43414afeb1db67B1842
 ```
@@ -273,7 +274,7 @@ open-attestation token-registry issue --network <NETWORK> --address <TOKEN_REGIS
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation token-registry mint --network goerli --address 0x6133f580aE903b8e79845340375cCfd78a45FF35 --tokenId 0x10ee711d151bc2139473a57531f91d961b639affb876b350c31d031059cdcc2c --to 0xB26B4941941C51a4885E5B7D3A1B861E54405f90
+open-attestation token-registry mint --network sepolia --address 0x6133f580aE903b8e79845340375cCfd78a45FF35 --tokenId 0x10ee711d151bc2139473a57531f91d961b639affb876b350c31d031059cdcc2c --to 0xB26B4941941C51a4885E5B7D3A1B861E54405f90
 
 
 ✔  success   Token with hash 0x10ee711d151bc2139473a57531f91d961b639affb876b350c31d031059cdcc2c has been issued on 0x6133f580aE903b8e79845340375cCfd78a45FF35 with the initial recipient being 0xB26B4941941C51a4885E5B7D3A1B861E54405f90
@@ -284,7 +285,6 @@ open-attestation token-registry mint --network goerli --address 0x6133f580aE903b
 #### Token Registry Roles
 
 Interfaces for the Assignment and Revocation of roles are available on the Token Registry repository.
-
 
 ### Document Store
 
@@ -299,7 +299,7 @@ open-attestation deploy document-store <store-name> [options]
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation deploy document-store "My Name" --network goerli
+open-attestation deploy document-store "My Name" --network sepolia
 
 ✔  success   Document store deployed at 0x4B127b8d5e53872d403ce43414afeb1db67B1842
 ```
@@ -307,7 +307,7 @@ open-attestation deploy document-store "My Name" --network goerli
 By default, the owner of the document store will be the deployer. You can specify a different owner using the `--owner` option:
 
 ```bash
-open-attestation deploy document-store "My Name" --owner 0x1234 --network goerli
+open-attestation deploy document-store "My Name" --owner 0x1234 --network sepolia
 ```
 
 #### Issue document to document store
@@ -321,7 +321,7 @@ open-attestation document-store issue --address <DOCUMENT_STORE_ADDRESS> --hash 
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation document-store issue --network goerli --address 0x19f89607b52268D0A19543e48F790c65750869c6 --hash 0x43033b53a462036304f526aeaf3aaeea8d905997d6fde3bb1a02188eadbaaec1
+open-attestation document-store issue --network sepolia --address 0x19f89607b52268D0A19543e48F790c65750869c6 --hash 0x43033b53a462036304f526aeaf3aaeea8d905997d6fde3bb1a02188eadbaaec1
 
 ✔  success   Document/Document Batch with hash 0x0c1a666aa55d17d26412bb57fbed96f40ec5a08e2f995a108faf45429ae3511f has been issued on 0x19f89607b52268D0A19543e48F790c65750869c6
 ```
@@ -337,7 +337,7 @@ open-attestation document-store revoke --address <DOCUMENT_STORE_ADDRESS> --hash
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation document-store revoke --network goerli --address 0x19f89607b52268D0A19543e48F790c65750869c6 --hash 0x43033b53a462036304f526aeaf3aaeea8d905997d6fde3bb1a02188eadbaaec1
+open-attestation document-store revoke --network sepolia --address 0x19f89607b52268D0A19543e48F790c65750869c6 --hash 0x43033b53a462036304f526aeaf3aaeea8d905997d6fde3bb1a02188eadbaaec1
 
 ✔  success   Document/Document Batch with hash 0x0c1a666aa55d17d26412bb57fbed96f40ec5a08e2f995a108faf45429ae3511f has been revoked on 0x19f89607b52268D0A19543e48F790c65750869c6
 ```
@@ -353,7 +353,7 @@ open-attestation document-store transfer-ownership --address <DOCUMENT_STORE_ADD
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation document-store transfer-ownership --address 0x80732bF5CA47A85e599f3ac9572F602c249C8A28 --new-owner 0xf81ea9d2c0133de728d28b8d7f186bed61079997 --network goerli
+open-attestation document-store transfer-ownership --address 0x80732bF5CA47A85e599f3ac9572F602c249C8A28 --new-owner 0xf81ea9d2c0133de728d28b8d7f186bed61079997 --network sepolia
 
 ✔  success   Ownership of document store 0x80732bF5CA47A85e599f3ac9572F602c249C8A28 has been transferred to new wallet 0xf81ea9d2c0133de728d28b8d7f186bed61079997
 ```
@@ -363,7 +363,7 @@ open-attestation document-store transfer-ownership --address 0x80732bF5CA47A85e5
 Verify if a document is valid.
 
 ```bash
-open-attestation verify --document ./examples/wrapped-documents/example.0.json --network goerli
+open-attestation verify --document ./examples/wrapped-documents/example.0.json --network sepolia
 
 …  awaiting  Verifying examples/wrapped-documents/example.0.json
 ✔  success   The document is valid
@@ -468,22 +468,22 @@ Example:
 
 ```bash
 # Using encrypted-wallet-path option
-open-attestation deploy document-store "My Name" --network goerli --encrypted-wallet-path /path/to/wallet.json
+open-attestation deploy document-store "My Name" --network sepolia --encrypted-wallet-path /path/to/wallet.json
 # Then you will be prompted to type your password to decrypt the wallet
 ? Wallet password [input is hidden]
 
 # Using environment variable
 export OA_PRIVATE_KEY=0000000000000000000000000000000000000000000000000000000000000001
-open-attestation deploy document-store "My Name" --network goerli
+open-attestation deploy document-store "My Name" --network sepolia
 unset OA_PRIVATE_KEY
 
 # Using private key stored in file
 echo -n 0000000000000000000000000000000000000000000000000000000000000002 >> ./examples/sample-key
-open-attestation deploy document-store "My Name" --network goerli --key-file ./examples/sample-key
+open-attestation deploy document-store "My Name" --network sepolia --key-file ./examples/sample-key
 rm ./examples/sample-key
 
 # Providing the key to the command
-open-attestation deploy document-store "My Name" --network goerli --key 0000000000000000000000000000000000000000000000000000000000000003
+open-attestation deploy document-store "My Name" --network sepolia --key 0000000000000000000000000000000000000000000000000000000000000003
 ```
 
 ### Config (Create configuration file)
@@ -528,7 +528,7 @@ open-attestation config create --output-dir ./example-configs --encrypted-wallet
 ? Wallet password [hidden]
 ? Using a config template URL? Yes
 ? Please enter the config template URL https://raw.githubusercontent.com/TradeTrust/tradetrust-config/master/build/config-reference-v3.json
-? Select Network goerli
+? Select Network sepolia
 ```
 
 #### Method 2: Using config-template-path option
@@ -547,7 +547,7 @@ open-attestation config create --output-dir ./example-configs --encrypted-wallet
 ? Wallet password [hidden]
 ? Using a config template URL? No
 ? Please enter the config template path </path/to>/config.json
-? Select Network goerli
+? Select Network sepolia
 ```
 
 ### Cancel pending transaction
@@ -570,11 +570,11 @@ open-attestation transaction cancel --nonce <pending transaction nonce> --gas-pr
 Examples:
 
 ```
-open-attestation transaction cancel --nonce 1 --gas-price 300 --network goerli --encrypted-wallet-path /path/to/wallet
+open-attestation transaction cancel --nonce 1 --gas-price 300 --network sepolia --encrypted-wallet-path /path/to/wallet
 ```
 
 ```
-open-attestation transaction cancel --transaction-hash 0x000 --network goerli --encrypted-wallet-path /path/to/wallet
+open-attestation transaction cancel --transaction-hash 0x000 --network sepolia --encrypted-wallet-path /path/to/wallet
 ```
 
 ### Title Escrow
@@ -657,7 +657,7 @@ open-attestation title-escrow surrender --token-registry <TOKEN_REGISTRY_ADDRESS
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation title-escrow reject-surrendered --token-registry 0x4933e30eF8A083f49d14759b2eafC94E56F0b3A7 --tokenId 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 --network goerli
+open-attestation title-escrow reject-surrendered --token-registry 0x4933e30eF8A083f49d14759b2eafC94E56F0b3A7 --tokenId 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 --network sepolia
 
 ✔  success   Transferable record with hash 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 has been surrendered.
 ```
@@ -673,7 +673,7 @@ open-attestation title-escrow reject-surrendered --token-registry <TOKEN_REGISTR
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation title-escrow reject-surrendered --token-registry 0x4933e30eF8A083f49d14759b2eafC94E56F0b3A7 --tokenId 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 --network goerli
+open-attestation title-escrow reject-surrendered --token-registry 0x4933e30eF8A083f49d14759b2eafC94E56F0b3A7 --tokenId 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 --network sepolia
 
 ✔  success   Surrendered transferable record with hash 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 has been rejected.
 ```
@@ -689,7 +689,7 @@ open-attestation title-escrow accept-surrendered --token-registry <TOKEN_REGISTR
 Example - with private key set in `OA_PRIVATE_KEY` environment variable (recommended). [More options](#providing-the-wallet).
 
 ```bash
-open-attestation title-escrow accept-surrendered --token-registry 0x4933e30eF8A083f49d14759b2eafC94E56F0b3A7 --tokenId 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 --network goerli
+open-attestation title-escrow accept-surrendered --token-registry 0x4933e30eF8A083f49d14759b2eafC94E56F0b3A7 --tokenId 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 --network sepolia
 
 ✔  success   Surrendered transferable record with hash 0x951b39bcaddc0e8882883db48ca258ca35ccb01fee328355f0dfda1ff9be9990 has been accepted.
 ```

--- a/src/__tests__/verify.v2.e2e.test.ts
+++ b/src/__tests__/verify.v2.e2e.test.ts
@@ -12,7 +12,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v2", "signed-documents", "did.json"),
       verbose: true,
-      network: "goerli",
+      network: "sepolia",
     });
     expect(signaleSuccessSpy).toHaveBeenCalledTimes(4);
     expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "The document is valid");
@@ -24,7 +24,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v2", "signed-documents", "dnsDid.json"),
       verbose: true,
-      network: "goerli",
+      network: "sepolia",
     });
     expect(signaleSuccessSpy).toHaveBeenCalledTimes(4);
     expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "The document is valid");
@@ -37,7 +37,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v2", "signed-documents", "did-invalid.json"),
       verbose: true,
-      network: "goerli",
+      network: "sepolia",
     });
     expect(signaleErrorSpy).toHaveBeenCalledTimes(4);
     expect(signaleErrorSpy).toHaveBeenNthCalledWith(1, "The document is not valid");

--- a/src/__tests__/verify.v3.e2e.test.ts
+++ b/src/__tests__/verify.v3.e2e.test.ts
@@ -12,7 +12,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v3", "signed-documents", "dnsdid-invalid-v3.json"),
       verbose: true,
-      network: "goerli",
+      network: "sepolia",
     });
     expect(signaleSuccessSpy).toHaveBeenCalledTimes(2);
     expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "The document has not been tampered");
@@ -25,7 +25,7 @@ describe("verify", () => {
     await handler({
       document: path.resolve("examples", "v3", "signed-documents", "did-v3.json"),
       verbose: true,
-      network: "goerli",
+      network: "sepolia",
     });
     expect(signaleSuccessSpy).toHaveBeenCalledTimes(4);
     expect(signaleSuccessSpy).toHaveBeenNthCalledWith(1, "The document is valid");

--- a/src/commands/config/config.type.ts
+++ b/src/commands/config/config.type.ts
@@ -8,7 +8,7 @@ export interface CreateConfigCommand {
   configTemplateUrl: string;
 }
 
-export enum SelectNetwork {
+export enum TestNetwork {
   Local = "local",
   Goerli = "goerli (deprecated)",
   Sepolia = "sepolia",

--- a/src/commands/config/config.type.ts
+++ b/src/commands/config/config.type.ts
@@ -7,3 +7,10 @@ export interface CreateConfigCommand {
   configTemplatePath: string;
   configTemplateUrl: string;
 }
+
+export enum SelectNetwork {
+  Local = "local",
+  Goerli = "goerli (deprecated)",
+  Sepolia = "sepolia",
+  Mumbai = "mumbai (polygon)",
+}

--- a/src/commands/config/create.ts
+++ b/src/commands/config/create.ts
@@ -4,8 +4,9 @@ import { error, info, success } from "signale";
 import { Argv } from "yargs";
 import { create } from "../../implementations/config/create";
 import { getLogger } from "../../logger";
-import { convertNetworkToNetworkCmdName, highlight } from "../../utils";
+import { highlight } from "../../utils";
 import { CreateConfigCommand, TestNetwork } from "./config.type";
+import { NetworkCmdName } from "../networks";
 
 const { trace } = getLogger("config:create");
 
@@ -75,4 +76,14 @@ export const handler = async (args: CreateConfigCommand): Promise<void> => {
       error(e.message);
     }
   }
+};
+
+const convertNetworkToNetworkCmdName = (selectedNetwork: TestNetwork): NetworkCmdName => {
+  const network = {
+    [TestNetwork.Local]: NetworkCmdName.Local,
+    [TestNetwork.Goerli]: NetworkCmdName.Goerli,
+    [TestNetwork.Sepolia]: NetworkCmdName.Sepolia,
+    [TestNetwork.Mumbai]: NetworkCmdName.Maticmum,
+  };
+  return network[selectedNetwork];
 };

--- a/src/commands/config/create.ts
+++ b/src/commands/config/create.ts
@@ -4,9 +4,8 @@ import { error, info, success } from "signale";
 import { Argv } from "yargs";
 import { create } from "../../implementations/config/create";
 import { getLogger } from "../../logger";
-import { highlight } from "../../utils";
-import { supportedNetwork } from "../networks";
-import { CreateConfigCommand } from "./config.type";
+import { convertNetworkToNetworkCmdName, highlight } from "../../utils";
+import { CreateConfigCommand, SelectNetwork } from "./config.type";
 
 const { trace } = getLogger("config:create");
 
@@ -60,13 +59,14 @@ export const handler = async (args: CreateConfigCommand): Promise<void> => {
       args.configTemplatePath = configTemplatePath;
     }
 
+    const networks = [SelectNetwork.Local, SelectNetwork.Goerli, SelectNetwork.Sepolia, SelectNetwork.Mumbai];
     const { network } = await inquirer.prompt({
       type: "list",
       name: "network",
       message: "Select Network",
-      choices: Object.keys(supportedNetwork),
+      choices: networks,
     });
-    args.network = network;
+    args.network = convertNetworkToNetworkCmdName(network);
 
     const outputPath = await create(args);
     success(`Config file successfully created and saved in ${highlight(outputPath)}`);

--- a/src/commands/config/create.ts
+++ b/src/commands/config/create.ts
@@ -5,7 +5,7 @@ import { Argv } from "yargs";
 import { create } from "../../implementations/config/create";
 import { getLogger } from "../../logger";
 import { convertNetworkToNetworkCmdName, highlight } from "../../utils";
-import { CreateConfigCommand, SelectNetwork } from "./config.type";
+import { CreateConfigCommand, TestNetwork } from "./config.type";
 
 const { trace } = getLogger("config:create");
 
@@ -59,7 +59,7 @@ export const handler = async (args: CreateConfigCommand): Promise<void> => {
       args.configTemplatePath = configTemplatePath;
     }
 
-    const networks = [SelectNetwork.Local, SelectNetwork.Goerli, SelectNetwork.Sepolia, SelectNetwork.Mumbai];
+    const networks = [TestNetwork.Local, TestNetwork.Goerli, TestNetwork.Sepolia, TestNetwork.Mumbai];
     const { network } = await inquirer.prompt({
       type: "list",
       name: "network",

--- a/src/implementations/config/__tests__/config-reference-v3.json
+++ b/src/implementations/config/__tests__/config-reference-v3.json
@@ -1,5 +1,5 @@
 {
-  "network": "goerli",
+  "network": "sepolia",
   "wallet": {
     "type": "ENCRYPTED_JSON",
     "encryptedJson": "<WALLET>"

--- a/src/implementations/config/__tests__/create.test.ts
+++ b/src/implementations/config/__tests__/create.test.ts
@@ -48,7 +48,7 @@ describe("create config file", () => {
   beforeEach(() => {
     folder = tmp.dirSync();
     args = {
-      network: NetworkCmdName.Goerli,
+      network: NetworkCmdName.Sepolia,
       outputDir: folder.name,
       encryptedWalletPath: "src/implementations/config/__tests__/wallet.json",
       configTemplatePath: "",
@@ -102,12 +102,12 @@ describe("create config file", () => {
 
     args.configTemplateUrl = "https://example.com";
 
-    const RinkebyArgs = { ...args, network: NetworkCmdName.Goerli };
+    const Args = { ...args, network: NetworkCmdName.Sepolia };
 
-    await createConfig(RinkebyArgs);
+    await createConfig(Args);
     const configFileAsString = fs.readFileSync(`${folder.name}/config.json`, "utf-8");
 
-    expect(JSON.parse(configFileAsString).network).toStrictEqual(NetworkCmdName.Goerli);
+    expect(JSON.parse(configFileAsString).network).toStrictEqual(NetworkCmdName.Sepolia);
   });
 
   it("should throw an error when detected config file with wrong form type", async () => {

--- a/src/implementations/config/__tests__/error-config-file.json
+++ b/src/implementations/config/__tests__/error-config-file.json
@@ -1,5 +1,5 @@
 {
-  "network": "goerli",
+  "network": "sepolia",
   "wallet": {
     "type": "ENCRYPTED_JSON",
     "encryptedJson": "{\"address\":\"1245e5b64d785b25057f7438f715f4aa5d965733\",\"id\":\"bf069d1b-4e88-487c-b695-f2e03ed7c1ff\",\"version\":3,\"Crypto\":{\"cipher\":\"aes-128-ctr\",\"cipherparams\":{\"iv\":\"1f34e7bfdaee4b0778ecea4c8d12a543\"},\"ciphertext\":\"4f6cee88b4776f4f6f8eedf3da11c6a13542aa4bb65d46a5c1bc44c100a96f54\",\"kdf\":\"scrypt\",\"kdfparams\":{\"salt\":\"d931e0ea13032fd70060e40054c5a76c0571f4d840ec91eeda1bf68bdcad84db\",\"n\":1,\"dklen\":32,\"p\":1,\"r\":8},\"mac\":\"06c7897e3ff04245bf4f0765d8b6a8482c1c9981cb46ae88f636f9c83cd0b891\"},\"x-ethers\":{\"client\":\"ethers.js\",\"gethFilename\":\"UTC--2020-05-15T09-03-13.0Z--1245e5b64d785b25057f7438f715f4aa5d965733\",\"mnemonicCounter\":\"99b7f5b6897dcfe22fc7aa00d8e3cf5e\",\"mnemonicCiphertext\":\"6e7c1d38f162e54050b125f1f51b43ca\",\"path\":\"m/44'/60'/0'/0/0\",\"version\":\"0.1\"}}"

--- a/src/implementations/config/__tests__/expected-config-file-output-v2.json
+++ b/src/implementations/config/__tests__/expected-config-file-output-v2.json
@@ -1,5 +1,5 @@
 {
-  "network": "goerli",
+  "network": "sepolia",
   "wallet": {
     "type": "ENCRYPTED_JSON",
     "encryptedJson": "{\"address\":\"709731d94d65b078496937655582401157c8a640\",\"id\":\"90167e7e-af5c-44b1-a6a3-2525300d1032\",\"version\":3,\"Crypto\":{\"cipher\":\"aes-128-ctr\",\"cipherparams\":{\"iv\":\"02004e981623b906938a205c24805bef\"},\"ciphertext\":\"06568387223b88fe860bfed23442966124fe38e463fdb5501a0a0f8b9d1519db\",\"kdf\":\"scrypt\",\"kdfparams\":{\"salt\":\"56b3c1e89f4d8a3f76564d4e6f64e832e46729c881764328a4509a2e96c052fe\",\"n\":131072,\"dklen\":32,\"p\":1,\"r\":8},\"mac\":\"7611744a709d7cac37379617e8ddd9f134658b7a99b09f55eeaa50b4af6e0d39\"},\"x-ethers\":{\"client\":\"ethers.js\",\"gethFilename\":\"UTC--2021-02-01T06-07-08.0Z--709731d94d65b078496937655582401157c8a640\",\"mnemonicCounter\":\"f2706de1481a3541e7b49885f9a21fa7\",\"mnemonicCiphertext\":\"7eb14f3487659d100e5dddac1cef72dd\",\"path\":\"m/44'/60'/0'/0/0\",\"locale\":\"en\",\"version\":\"0.1\"}}"
@@ -24,7 +24,7 @@
           }
         ],
         "network": {
-          "chainId": "5",
+          "chainId": "11155111",
           "chain": "ETH"
         }
       }
@@ -44,7 +44,7 @@
           }
         ],
         "network": {
-          "chainId": "5",
+          "chainId": "11155111",
           "chain": "ETH"
         }
       }
@@ -68,7 +68,7 @@
           }
         ],
         "network": {
-          "chainId": "5",
+          "chainId": "11155111",
           "chain": "ETH"
         }
       }

--- a/src/implementations/config/__tests__/expected-config-file-output-v3.json
+++ b/src/implementations/config/__tests__/expected-config-file-output-v3.json
@@ -1,5 +1,5 @@
 {
-  "network": "goerli",
+  "network": "sepolia",
   "wallet": {
     "type": "ENCRYPTED_JSON",
     "encryptedJson": "{\"address\":\"709731d94d65b078496937655582401157c8a640\",\"id\":\"90167e7e-af5c-44b1-a6a3-2525300d1032\",\"version\":3,\"Crypto\":{\"cipher\":\"aes-128-ctr\",\"cipherparams\":{\"iv\":\"02004e981623b906938a205c24805bef\"},\"ciphertext\":\"06568387223b88fe860bfed23442966124fe38e463fdb5501a0a0f8b9d1519db\",\"kdf\":\"scrypt\",\"kdfparams\":{\"salt\":\"56b3c1e89f4d8a3f76564d4e6f64e832e46729c881764328a4509a2e96c052fe\",\"n\":131072,\"dklen\":32,\"p\":1,\"r\":8},\"mac\":\"7611744a709d7cac37379617e8ddd9f134658b7a99b09f55eeaa50b4af6e0d39\"},\"x-ethers\":{\"client\":\"ethers.js\",\"gethFilename\":\"UTC--2021-02-01T06-07-08.0Z--709731d94d65b078496937655582401157c8a640\",\"mnemonicCounter\":\"f2706de1481a3541e7b49885f9a21fa7\",\"mnemonicCiphertext\":\"7eb14f3487659d100e5dddac1cef72dd\",\"path\":\"m/44'/60'/0'/0/0\",\"locale\":\"en\",\"version\":\"0.1\"}}"
@@ -47,7 +47,7 @@
           "type": "OpenAttestationIssuer"
         },
         "network": {
-          "chainId": "5",
+          "chainId": "11155111",
           "chain": "ETH"
         }
       },
@@ -186,7 +186,7 @@
           "type": "OpenAttestationIssuer"
         },
         "network": {
-          "chainId": "5",
+          "chainId": "11155111",
           "chain": "ETH"
         }
       },
@@ -655,7 +655,7 @@
           "type": "OpenAttestationIssuer"
         },
         "network": {
-          "chainId": "5",
+          "chainId": "11155111",
           "chain": "ETH"
         }
       },
@@ -833,7 +833,7 @@
           "type": "OpenAttestationIssuer"
         },
         "network": {
-          "chainId": "5",
+          "chainId": "11155111",
           "chain": "ETH"
         }
       },

--- a/src/implementations/config/__tests__/helpers.test.ts
+++ b/src/implementations/config/__tests__/helpers.test.ts
@@ -30,13 +30,13 @@ describe("getConfigFile", () => {
 describe("getConfigWithUpdatedNetwork", () => {
   it("should update config file with network for V2", () => {
     expect(
-      getConfigWithUpdatedNetwork({ configFile: ConfigFileV2 as ConfigFile, network: NetworkCmdName.Goerli }).network
-    ).toStrictEqual(NetworkCmdName.Goerli);
+      getConfigWithUpdatedNetwork({ configFile: ConfigFileV2 as ConfigFile, network: NetworkCmdName.Sepolia }).network
+    ).toStrictEqual(NetworkCmdName.Sepolia);
   });
   it("should update config file with network for V3", () => {
     expect(
-      getConfigWithUpdatedNetwork({ configFile: ConfigFileV3 as ConfigFile, network: NetworkCmdName.Goerli }).network
-    ).toStrictEqual(NetworkCmdName.Goerli);
+      getConfigWithUpdatedNetwork({ configFile: ConfigFileV3 as ConfigFile, network: NetworkCmdName.Sepolia }).network
+    ).toStrictEqual(NetworkCmdName.Sepolia);
   });
 });
 
@@ -64,7 +64,7 @@ describe("getConfigWithUpdatedForms", () => {
     const config = getConfigWithUpdatedForms({
       configFile: configWithWallet as ConfigFile,
       chain: {
-        id: "5",
+        id: "11155111",
         currency: "ETH",
       },
       documentStoreAddress: "0xC378aBE13cf18a64fB2f913647bd4Fe054C9eaEd",
@@ -84,7 +84,7 @@ describe("getConfigWithUpdatedForms", () => {
     const config = getConfigWithUpdatedForms({
       configFile: configWithWallet as ConfigFile,
       chain: {
-        id: "5",
+        id: "11155111",
         currency: "ETH",
       },
       documentStoreAddress: "0xC378aBE13cf18a64fB2f913647bd4Fe054C9eaEd",

--- a/src/implementations/config/__tests__/input-config-file.json
+++ b/src/implementations/config/__tests__/input-config-file.json
@@ -1,5 +1,5 @@
 {
-  "network": "goerli",
+  "network": "sepolia",
   "wallet": {
     "type": "ENCRYPTED_JSON",
     "encryptedJson": "{\"address\":\"1245e5b64d785b25057f7438f715f4aa5d965733\",\"id\":\"bf069d1b-4e88-487c-b695-f2e03ed7c1ff\",\"version\":3,\"Crypto\":{\"cipher\":\"aes-128-ctr\",\"cipherparams\":{\"iv\":\"1f34e7bfdaee4b0778ecea4c8d12a543\"},\"ciphertext\":\"4f6cee88b4776f4f6f8eedf3da11c6a13542aa4bb65d46a5c1bc44c100a96f54\",\"kdf\":\"scrypt\",\"kdfparams\":{\"salt\":\"d931e0ea13032fd70060e40054c5a76c0571f4d840ec91eeda1bf68bdcad84db\",\"n\":1,\"dklen\":32,\"p\":1,\"r\":8},\"mac\":\"06c7897e3ff04245bf4f0765d8b6a8482c1c9981cb46ae88f636f9c83cd0b891\"},\"x-ethers\":{\"client\":\"ethers.js\",\"gethFilename\":\"UTC--2020-05-15T09-03-13.0Z--1245e5b64d785b25057f7438f715f4aa5d965733\",\"mnemonicCounter\":\"99b7f5b6897dcfe22fc7aa00d8e3cf5e\",\"mnemonicCiphertext\":\"6e7c1d38f162e54050b125f1f51b43ca\",\"path\":\"m/44'/60'/0'/0/0\",\"version\":\"0.1\"}}"

--- a/src/implementations/deploy/document-store/document-store.test.ts
+++ b/src/implementations/deploy/document-store/document-store.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/document-store");
 const deployParams: DeployDocumentStoreCommand = {
   storeName: "Test Document Store",
   owner: "0x1234",
-  network: "goerli",
+  network: "sepolia",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   dryRun: false,
 };
@@ -36,7 +36,7 @@ describe("document-store", () => {
 
       await deployDocumentStore({
         storeName: "Test",
-        network: "goerli",
+        network: "sepolia",
         dryRun: false,
       });
 
@@ -47,7 +47,7 @@ describe("document-store", () => {
     it("should take in the key from key file", async () => {
       await deployDocumentStore({
         storeName: "Test",
-        network: "goerli",
+        network: "sepolia",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         dryRun: false,
       });
@@ -77,7 +77,7 @@ describe("document-store", () => {
       await expect(
         deployDocumentStore({
           storeName: "Test",
-          network: "goerli",
+          network: "sepolia",
           dryRun: false,
         })
       ).rejects.toThrow(
@@ -90,7 +90,7 @@ describe("document-store", () => {
 
       await deployDocumentStore({
         storeName: "Test",
-        network: "goerli",
+        network: "sepolia",
         dryRun: false,
       });
 

--- a/src/implementations/deploy/title-escrow-factory/title-escrow-factory.test.ts
+++ b/src/implementations/deploy/title-escrow-factory/title-escrow-factory.test.ts
@@ -7,7 +7,7 @@ import { deployTitleEscrowFactory } from "./title-escrow-factory";
 jest.mock("@govtechsg/token-registry/contracts");
 
 const deployParams: DeployTitleEscrowFactoryCommand = {
-  network: "goerli",
+  network: "sepolia",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   dryRun: false,
 };
@@ -34,7 +34,7 @@ describe("title escrow factory", () => {
       process.env.OA_PRIVATE_KEY = "0000000000000000000000000000000000000000000000000000000000000002";
 
       await deployTitleEscrowFactory({
-        network: "goerli",
+        network: "sepolia",
         dryRun: false,
       });
 
@@ -44,7 +44,7 @@ describe("title escrow factory", () => {
 
     it("should take in the key from key file", async () => {
       await deployTitleEscrowFactory({
-        network: "goerli",
+        network: "sepolia",
         keyFile: join(__dirname, "..", "..", "..", "..", "examples", "sample-key"),
         dryRun: false,
       });
@@ -71,7 +71,7 @@ describe("title escrow factory", () => {
     it("should throw when keys are not found anywhere", async () => {
       await expect(
         deployTitleEscrowFactory({
-          network: "goerli",
+          network: "sepolia",
           dryRun: false,
         })
       ).rejects.toThrow(

--- a/src/implementations/deploy/token-registry/token-registry.test.ts
+++ b/src/implementations/deploy/token-registry/token-registry.test.ts
@@ -7,7 +7,7 @@ import { DeploymentEvent } from "@govtechsg/token-registry/dist/contracts/contra
 const deployParams: DeployTokenRegistryCommand = {
   registryName: "Test",
   registrySymbol: "Tst",
-  network: "goerli",
+  network: "sepolia",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   dryRun: false,
 };
@@ -78,7 +78,7 @@ describe("deploy Token Registry", () => {
       deployTokenRegistry({
         registryName: "Test",
         registrySymbol: "Tst",
-        network: "goerli",
+        network: "sepolia",
         dryRun: false,
       })
     ).rejects.toThrow(

--- a/src/implementations/document-store/issue.test.ts
+++ b/src/implementations/document-store/issue.test.ts
@@ -10,7 +10,7 @@ jest.mock("@govtechsg/document-store");
 const deployParams: DocumentStoreIssueCommand = {
   hash: "0xabcd",
   address: "0x1234",
-  network: "goerli",
+  network: "sepolia",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   dryRun: false,
 };
@@ -50,7 +50,7 @@ describe("issue document-store", () => {
     await issueToDocumentStore({
       hash: "0xabcd",
       address: "0x1234",
-      network: "goerli",
+      network: "sepolia",
       dryRun: false,
     });
 
@@ -74,7 +74,7 @@ describe("issue document-store", () => {
     await issueToDocumentStore({
       hash: "0xabcd",
       address: "0x1234",
-      network: "goerli",
+      network: "sepolia",
       keyFile: join(__dirname, "..", "..", "..", "examples", "sample-key"),
       dryRun: false,
     });
@@ -107,7 +107,7 @@ describe("issue document-store", () => {
       issueToDocumentStore({
         hash: "0xabcd",
         address: "0x1234",
-        network: "goerli",
+        network: "sepolia",
         dryRun: false,
       })
     ).rejects.toThrow(

--- a/src/implementations/document-store/revoke.test.ts
+++ b/src/implementations/document-store/revoke.test.ts
@@ -11,7 +11,7 @@ jest.mock("@govtechsg/document-store");
 const deployParams: DocumentStoreRevokeCommand = {
   hash: "0xabcd",
   address: "0x1234",
-  network: "goerli",
+  network: "sepolia",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   dryRun: false,
 };
@@ -74,7 +74,7 @@ describe("document-store", () => {
       await revokeToDocumentStore({
         hash: "0xabcd",
         address: "0x1234",
-        network: "goerli",
+        network: "sepolia",
         dryRun: false,
       });
 
@@ -86,7 +86,7 @@ describe("document-store", () => {
       await revokeToDocumentStore({
         hash: "0xabcd",
         address: "0x1234",
-        network: "goerli",
+        network: "sepolia",
         keyFile: join(__dirname, "..", "..", "..", "examples", "sample-key"),
         dryRun: false,
       });
@@ -107,7 +107,7 @@ describe("document-store", () => {
         revokeToDocumentStore({
           hash: "0xabcd",
           address: "0x1234",
-          network: "goerli",
+          network: "sepolia",
           dryRun: false,
         })
       ).rejects.toThrow(

--- a/src/implementations/document-store/transfer-ownership.test.ts
+++ b/src/implementations/document-store/transfer-ownership.test.ts
@@ -11,7 +11,7 @@ jest.mock("@govtechsg/document-store");
 const deployParams: DocumentStoreTransferOwnershipCommand = {
   newOwner: "0xabcd",
   address: "0x1234",
-  network: "goerli",
+  network: "sepolia",
   key: "0000000000000000000000000000000000000000000000000000000000000001",
   dryRun: false,
 };
@@ -77,7 +77,7 @@ describe("document-store", () => {
       await transferDocumentStoreOwnershipToWallet({
         newOwner: "0xabcd",
         address: "0x1234",
-        network: "goerli",
+        network: "sepolia",
         dryRun: false,
       });
 
@@ -88,7 +88,7 @@ describe("document-store", () => {
       await transferDocumentStoreOwnershipToWallet({
         newOwner: "0xabcd",
         address: "0x1234",
-        network: "goerli",
+        network: "sepolia",
         keyFile: join(__dirname, "..", "..", "..", "examples", "sample-key"),
         dryRun: false,
       });

--- a/src/implementations/title-escrow/acceptSurrendered.test.ts
+++ b/src/implementations/title-escrow/acceptSurrendered.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/token-registry/contracts");
 const acceptSurrenderedDocumentParams: TitleEscrowSurrenderDocumentCommand = {
   tokenRegistry: "0x1122",
   tokenId: "0x12345",
-  network: "goerli",
+  network: "sepolia",
   dryRun: false,
 };
 

--- a/src/implementations/title-escrow/endorseNominatedBeneficiary.test.ts
+++ b/src/implementations/title-escrow/endorseNominatedBeneficiary.test.ts
@@ -10,7 +10,7 @@ const endorseNominatedBeneficiaryParams: TitleEscrowNominateBeneficiaryCommand =
   tokenId: "0xzyxw",
   tokenRegistry: "0x1234",
   newBeneficiary: "0x1232",
-  network: "goerli",
+  network: "sepolia",
   dryRun: false,
 };
 

--- a/src/implementations/title-escrow/nominateBeneficiary.test.ts
+++ b/src/implementations/title-escrow/nominateBeneficiary.test.ts
@@ -10,7 +10,7 @@ const nominateBeneficiaryParams: TitleEscrowNominateBeneficiaryCommand = {
   newBeneficiary: "0fosui",
   tokenId: "0xzyxw",
   tokenRegistry: "0x1234",
-  network: "goerli",
+  network: "sepolia",
   dryRun: false,
 };
 

--- a/src/implementations/title-escrow/rejectSurrendered.test.ts
+++ b/src/implementations/title-escrow/rejectSurrendered.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/token-registry/contracts");
 const rejectSurrenderedDocumentParams: TitleEscrowSurrenderDocumentCommand = {
   tokenRegistry: "0x1122",
   tokenId: "0x12345",
-  network: "goerli",
+  network: "sepolia",
   dryRun: false,
 };
 

--- a/src/implementations/title-escrow/surrenderDocument.test.ts
+++ b/src/implementations/title-escrow/surrenderDocument.test.ts
@@ -9,7 +9,7 @@ jest.mock("@govtechsg/token-registry/contracts");
 const surrenderDocumentParams: TitleEscrowSurrenderDocumentCommand = {
   tokenRegistry: "0x1122",
   tokenId: "0x12345",
-  network: "goerli",
+  network: "sepolia",
   dryRun: false,
 };
 

--- a/src/implementations/title-escrow/transferHolder.test.ts
+++ b/src/implementations/title-escrow/transferHolder.test.ts
@@ -10,7 +10,7 @@ const transferHolderParams: TitleEscrowTransferHolderCommand = {
   newHolder: "0xabcd",
   tokenId: "0xzyxw",
   tokenRegistry: "0x1234",
-  network: "goerli",
+  network: "sepolia",
   dryRun: false,
 };
 

--- a/src/implementations/title-escrow/transferOwners.test.ts
+++ b/src/implementations/title-escrow/transferOwners.test.ts
@@ -11,7 +11,7 @@ const endorseChangeOwnersParams: TitleEscrowEndorseTransferOfOwnersCommand = {
   newOwner: "0fosui",
   tokenId: "0xzyxw",
   tokenRegistry: "0x1234",
-  network: "goerli",
+  network: "sepolia",
   dryRun: false,
 };
 

--- a/src/implementations/token-registry/issue.test.ts
+++ b/src/implementations/token-registry/issue.test.ts
@@ -12,7 +12,7 @@ const deployParams: TokenRegistryIssueCommand = {
   holder: "0xabce",
   tokenId: "0xzyxw",
   address: "0x1234",
-  network: "goerli",
+  network: "sepolia",
   dryRun: false,
 };
 

--- a/src/implementations/transaction/transaction.test.ts
+++ b/src/implementations/transaction/transaction.test.ts
@@ -28,7 +28,7 @@ describe("document-store", () => {
 
       await cancelTransaction({
         transactionHash: "0x456bba58226f03e3fb7d72b5143ceecfb6bfb66b00586929f6d60890ec264c2c",
-        network: "goerli",
+        network: "sepolia",
         keyFile: path.resolve(__dirname, "./key.file"),
       });
       expect(signaleInfoSpy).toHaveBeenNthCalledWith(1, "Transaction detail retrieved. Nonce: 10, Gas-price: 3");

--- a/src/implementations/utils/__tests__/wallet.test.ts
+++ b/src/implementations/utils/__tests__/wallet.test.ts
@@ -20,17 +20,17 @@ describe("wallet", () => {
   });
   it("should return the wallet when providing the key using environment variable", async () => {
     process.env.OA_PRIVATE_KEY = privateKey;
-    const wallet = await getWalletOrSigner({ network: "goerli" });
+    const wallet = await getWalletOrSigner({ network: "sepolia" });
     expect(await wallet.getAddress()).toStrictEqual(walletAddress);
     expect(wallet.privateKey).toStrictEqual(privateKey);
   });
   it("should return the wallet when providing the key using key option", async () => {
-    const wallet = await getWalletOrSigner({ network: "goerli", key: privateKey });
+    const wallet = await getWalletOrSigner({ network: "sepolia", key: privateKey });
     expect(await wallet.getAddress()).toStrictEqual(walletAddress);
     expect(wallet.privateKey).toStrictEqual(privateKey);
   });
   it("should return the wallet when providing the key using key-file option", async () => {
-    const wallet = await getWalletOrSigner({ network: "goerli", keyFile: path.resolve(__dirname, "./key.file") });
+    const wallet = await getWalletOrSigner({ network: "sepolia", keyFile: path.resolve(__dirname, "./key.file") });
     expect(await wallet.getAddress()).toStrictEqual(walletAddress);
     expect(wallet.privateKey).toStrictEqual(privateKey);
   });
@@ -38,7 +38,7 @@ describe("wallet", () => {
     promptMock.mockReturnValue({ password: "password123" });
 
     const wallet = await getWalletOrSigner({
-      network: "goerli",
+      network: "sepolia",
       encryptedWalletPath: path.resolve(__dirname, "./wallet.json"),
       progress: () => void 0, // shut up progress bar
     });
@@ -50,14 +50,14 @@ describe("wallet", () => {
 
     await expect(
       getWalletOrSigner({
-        network: "goerli",
+        network: "sepolia",
         encryptedWalletPath: path.resolve(__dirname, "./wallet.json"),
         progress: () => void 0, // shut up progress bar
       })
     ).rejects.toStrictEqual(new Error("invalid password"));
   });
   it("should throw an error when no option is provided", async () => {
-    await expect(getWalletOrSigner({ network: "goerli" })).rejects.toStrictEqual(
+    await expect(getWalletOrSigner({ network: "sepolia" })).rejects.toStrictEqual(
       new Error(
         "No private key found in OA_PRIVATE_KEY, key, key-file, please supply at least one or supply an encrypted wallet path, or provide aws kms signer information"
       )

--- a/src/implementations/wallet/create.ts
+++ b/src/implementations/wallet/create.ts
@@ -23,7 +23,7 @@ export const create = async ({
   fs.writeFileSync(outputPath, json);
 
   signale.info(`Wallet with public address ${highlight(wallet.address)} successfully created.`);
-  signale.info(`Find more details at ${getEtherscanAddress({ network: "goerli" })}/address/${wallet.address}`);
+  signale.info(`Find more details at ${getEtherscanAddress({ network: "sepolia" })}/address/${wallet.address}`);
 
   return outputPath;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,7 +44,7 @@ export const getErrorMessage = function (error: unknown): string {
   }
 };
 
-export const convertNetworkToNetworkCmdName = (selectedNetwork: SelectNetwork) => {
+export const convertNetworkToNetworkCmdName = (selectedNetwork: SelectNetwork): NetworkCmdName => {
   const network = {
     [SelectNetwork.Local]: NetworkCmdName.Local,
     [SelectNetwork.Goerli]: NetworkCmdName.Goerli,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import chalk from "chalk";
 import { getSupportedNetwork } from "./commands/networks";
+import { SelectNetwork } from "./commands/config/config.type";
+import { NetworkCmdName } from "./commands/networks";
 
 export const getEtherscanAddress = ({ network }: { network: string }): string => getSupportedNetwork(network).explorer;
 
@@ -40,4 +42,14 @@ export const getErrorMessage = function (error: unknown): string {
   } else {
     return extractErrorMessage(error);
   }
+};
+
+export const convertNetworkToNetworkCmdName = (selectedNetwork: SelectNetwork) => {
+  const network = {
+    [SelectNetwork.Local]: NetworkCmdName.Local,
+    [SelectNetwork.Goerli]: NetworkCmdName.Goerli,
+    [SelectNetwork.Sepolia]: NetworkCmdName.Sepolia,
+    [SelectNetwork.Mumbai]: NetworkCmdName.Maticmum,
+  };
+  return network[selectedNetwork];
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,5 @@
 import chalk from "chalk";
 import { getSupportedNetwork } from "./commands/networks";
-import { TestNetwork } from "./commands/config/config.type";
-import { NetworkCmdName } from "./commands/networks";
 
 export const getEtherscanAddress = ({ network }: { network: string }): string => getSupportedNetwork(network).explorer;
 
@@ -42,14 +40,4 @@ export const getErrorMessage = function (error: unknown): string {
   } else {
     return extractErrorMessage(error);
   }
-};
-
-export const convertNetworkToNetworkCmdName = (selectedNetwork: TestNetwork): NetworkCmdName => {
-  const network = {
-    [TestNetwork.Local]: NetworkCmdName.Local,
-    [TestNetwork.Goerli]: NetworkCmdName.Goerli,
-    [TestNetwork.Sepolia]: NetworkCmdName.Sepolia,
-    [TestNetwork.Mumbai]: NetworkCmdName.Maticmum,
-  };
-  return network[selectedNetwork];
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { getSupportedNetwork } from "./commands/networks";
-import { SelectNetwork } from "./commands/config/config.type";
+import { TestNetwork } from "./commands/config/config.type";
 import { NetworkCmdName } from "./commands/networks";
 
 export const getEtherscanAddress = ({ network }: { network: string }): string => getSupportedNetwork(network).explorer;
@@ -44,12 +44,12 @@ export const getErrorMessage = function (error: unknown): string {
   }
 };
 
-export const convertNetworkToNetworkCmdName = (selectedNetwork: SelectNetwork): NetworkCmdName => {
+export const convertNetworkToNetworkCmdName = (selectedNetwork: TestNetwork): NetworkCmdName => {
   const network = {
-    [SelectNetwork.Local]: NetworkCmdName.Local,
-    [SelectNetwork.Goerli]: NetworkCmdName.Goerli,
-    [SelectNetwork.Sepolia]: NetworkCmdName.Sepolia,
-    [SelectNetwork.Mumbai]: NetworkCmdName.Maticmum,
+    [TestNetwork.Local]: NetworkCmdName.Local,
+    [TestNetwork.Goerli]: NetworkCmdName.Goerli,
+    [TestNetwork.Sepolia]: NetworkCmdName.Sepolia,
+    [TestNetwork.Mumbai]: NetworkCmdName.Maticmum,
   };
   return network[selectedNetwork];
 };


### PR DESCRIPTION
## Summary

Goerli Testnet has been deprecated. This PR is to update test cases to sepolia. 

*Note: The removal of Goerli Testnet for the commands should not be in this PR, we should be able to run cmd for goerli testnet until October 2023.*

## Changes

- Update test files to use Sepolia.
- Update Config creation cmd to only use Testnets.

## Issues

https://www.pivotaltracker.com/story/show/185533855