### PR TITLE
Updated RPC for XDC Network

### DIFF
--- a/src/common/networks.ts
+++ b/src/common/networks.ts
@@ -75,14 +75,14 @@ export const supportedNetwork: {
   },
   [NetworkCmdName.XDC]: {
     explorer: "https://xdcscan.io",
-    provider: jsonRpcProvider("https://erpc.xinfin.network"),
+    provider: jsonRpcProvider("https://rpc.ankr.com/xdc"),
     networkId: 50,
     networkName: NetworkCmdName.XDC,
     currency: "XDC",
   },
   [NetworkCmdName.XDCApothem]: {
     explorer: "https://apothem.xdcscan.io",
-    provider: jsonRpcProvider("https://erpc.apothem.network"),
+    provider: jsonRpcProvider("https://rpc.ankr.com/xdc_testnet"),
     networkId: 51,
     networkName: NetworkCmdName.XDCApothem,
     currency: "XDC",


### PR DESCRIPTION
## Summary

What is the background of this pull request?
Updated the RPC URLs for the XDC network on mainnet and testnet.

## Changes

RPC has been updated in the configurations.

<img width="341" alt="Screenshot 2024-02-16 at 10 22 47 AM" src="https://github.com/Open-Attestation/open-attestation-cli/assets/39335466/87bcc9e8-8ae7-4f21-b48c-1c86eaae66d1">
