### PR TITLE
feat: remove gasFees from callStatics

### DIFF
--- a/src/implementations/document-store/grant-role.ts
+++ b/src/implementations/document-store/grant-role.ts
@@ -31,7 +31,7 @@ export const grantDocumentStoreRole = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await documentStore.callStatic.grantRole(roleString, account, { ...gasFees });
+  await documentStore.callStatic.grantRole(roleString, account);
   signale.await(`Sending transaction to pool`);
   const transaction = await documentStore.grantRole(roleString, account, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/document-store/issue.ts
+++ b/src/implementations/document-store/issue.ts
@@ -28,7 +28,7 @@ export const issueToDocumentStore = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await documentStore.callStatic.issue(hash, { ...gasFees });
+  await documentStore.callStatic.issue(hash);
   signale.await(`Sending transaction to pool`);
   const transaction = await documentStore.issue(hash, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/document-store/revoke-role.ts
+++ b/src/implementations/document-store/revoke-role.ts
@@ -31,7 +31,7 @@ export const revokeDocumentStoreRole = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await documentStore.callStatic.revokeRole(roleString, account, { ...gasFees });
+  await documentStore.callStatic.revokeRole(roleString, account);
   signale.await(`Sending transaction to pool`);
   const transaction = await documentStore.revokeRole(roleString, account, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/document-store/revoke.ts
+++ b/src/implementations/document-store/revoke.ts
@@ -27,7 +27,7 @@ export const revokeToDocumentStore = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await documentStore.callStatic.revoke(hash, { ...gasFees });
+  await documentStore.callStatic.revoke(hash);
   signale.await(`Sending transaction to pool`);
   const transaction = await documentStore.revoke(hash, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/document-store/transfer-ownership.ts
+++ b/src/implementations/document-store/transfer-ownership.ts
@@ -39,13 +39,13 @@ export const transferDocumentStoreOwnership = async ({
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
   signale.await(`Sending transaction to pool`);
-  await documentStore.callStatic.grantRole(roleString, newOwner, { ...gasFees });
+  await documentStore.callStatic.grantRole(roleString, newOwner);
   const grantTransaction = await documentStore.grantRole(roleString, newOwner, { ...gasFees });
   success(`Document store ${address}'s ownership has been granted to wallet ${newOwner}`);
   info(`Transaction details at: ${getEtherscanAddress({ network: network })}/tx/${grantTransaction.hash}`);
   trace(`Tx hash: ${grantTransaction.hash}`);
   trace(`Block Number: ${grantTransaction.blockNumber}`);
-  await documentStore.callStatic.revokeRole(roleString, ownerAddress, { ...gasFees });
+  await documentStore.callStatic.revokeRole(roleString, ownerAddress);
   const revokeTransaction = await documentStore.revokeRole(roleString, ownerAddress, { ...gasFees });
   success(`Document store ${address}'s ownership has been revoked from wallet ${ownerAddress}`);
   info(`Transaction details at: ${getEtherscanAddress({ network: network })}/tx/${revokeTransaction.hash}`);

--- a/src/implementations/title-escrow/acceptSurrendered.ts
+++ b/src/implementations/title-escrow/acceptSurrendered.ts
@@ -29,7 +29,7 @@ export const acceptSurrendered = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await tokenRegistryInstance.callStatic.burn(tokenId, { ...gasFees });
+  await tokenRegistryInstance.callStatic.burn(tokenId);
   signale.await(`Sending transaction to pool`);
   const transaction = await tokenRegistryInstance.burn(tokenId, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/title-escrow/endorseNominatedBeneficiary.ts
+++ b/src/implementations/title-escrow/endorseNominatedBeneficiary.ts
@@ -35,7 +35,7 @@ export const endorseNominatedBeneficiary = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await titleEscrow.callStatic.transferBeneficiary(nominatedBeneficiary, { ...gasFees });
+  await titleEscrow.callStatic.transferBeneficiary(nominatedBeneficiary);
   signale.await(`Sending transaction to pool`);
   const transaction = await titleEscrow.transferBeneficiary(nominatedBeneficiary, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/title-escrow/nominateBeneficiary.ts
+++ b/src/implementations/title-escrow/nominateBeneficiary.ts
@@ -32,7 +32,7 @@ export const nominateBeneficiary = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await titleEscrow.callStatic.nominate(newBeneficiary, { ...gasFees });
+  await titleEscrow.callStatic.nominate(newBeneficiary);
   signale.await(`Sending transaction to pool`);
   const transaction = await titleEscrow.nominate(newBeneficiary, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/title-escrow/rejectSurrendered.ts
+++ b/src/implementations/title-escrow/rejectSurrendered.ts
@@ -28,7 +28,7 @@ export const rejectSurrendered = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await tokenRegistryInstance.callStatic.restore(tokenId, { ...gasFees });
+  await tokenRegistryInstance.callStatic.restore(tokenId);
   signale.await(`Sending transaction to pool`);
   const transaction = await tokenRegistryInstance.restore(tokenId, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/title-escrow/surrenderDocument.ts
+++ b/src/implementations/title-escrow/surrenderDocument.ts
@@ -28,7 +28,7 @@ export const surrenderDocument = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await titleEscrow.callStatic.surrender({ ...gasFees });
+  await titleEscrow.callStatic.surrender();
   signale.await(`Sending transaction to pool`);
   const transaction = await titleEscrow.surrender({ ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/title-escrow/transferHolder.ts
+++ b/src/implementations/title-escrow/transferHolder.ts
@@ -30,7 +30,7 @@ export const transferHolder = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await titleEscrow.callStatic.transferHolder(to, { ...gasFees });
+  await titleEscrow.callStatic.transferHolder(to);
   signale.await(`Sending transaction to pool`);
   const transaction = await titleEscrow.transferHolder(to, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/title-escrow/transferOwners.ts
+++ b/src/implementations/title-escrow/transferOwners.ts
@@ -32,7 +32,7 @@ export const transferOwners = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await titleEscrow.callStatic.transferOwners(newOwner, newHolder, { ...gasFees });
+  await titleEscrow.callStatic.transferOwners(newOwner, newHolder);
   signale.await(`Sending transaction to pool`);
   const transaction = await titleEscrow.transferOwners(newOwner, newHolder, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);

--- a/src/implementations/token-registry/issue.ts
+++ b/src/implementations/token-registry/issue.ts
@@ -30,7 +30,7 @@ export const issueToTokenRegistry = async ({
   const gasFees = await getGasFees({ provider: wallet.provider, ...rest });
   trace(`Gas maxFeePerGas: ${gasFees.maxFeePerGas}`);
   trace(`Gas maxPriorityFeePerGas: ${gasFees.maxPriorityFeePerGas}`);
-  await tokenRegistry.callStatic.mint(beneficiary, holder, tokenId, { ...gasFees });
+  await tokenRegistry.callStatic.mint(beneficiary, holder, tokenId);
   signale.await(`Sending transaction to pool`);
   const transaction = await tokenRegistry.mint(beneficiary, holder, tokenId, { ...gasFees });
   trace(`Tx hash: ${transaction.hash}`);


### PR DESCRIPTION
Background:
[Original PR](https://github.com/Open-Attestation/open-attestation-cli/pull/193) to add callStatic.
Commands called on the Sepolia network fails when we try to invoke the callStatic methods with `gasFees`.

In this PR we remove that param from the callStatic invocations to still allow for the added validation but resolve such errors.