### PR TITLE
fix: add src to binary path

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.ts",
   "types": "dist/types/index.d.ts",
   "bin": {
-    "open-attestation": "dist/cjs/index.js",
-    "oa": "dist/cjs/index.js"
+    "open-attestation": "dist/cjs/src/index.js",
+    "oa": "dist/cjs/src/index.js"
   },
   "scripts": {
     "dev": "ts-node src/index.ts",


### PR DESCRIPTION
With addition of `"performance-tests/**/*.ts"` in tsconfig.json, npm run build outputs 2 folders to `dist/cjs` instead of one.

This PR adds the `src` folder to allow the `pkg` command to locate index.js correctly.