### PR TITLE
feat: migrate polygon mumbai to amoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Upon installation, a configuration folder will be created at `~/.config/open-att
 | `1`        | Ethereum Mainnet         | `mainnet`    | Production |
 | `11155111` | Ethereum Testnet Sepolia | `sepolia`    | Test       |
 | `137`      | Polygon Mainnet          | `polygon`    | Production |
-| `80001`    | Polygon Testnet Mumbai   | `mumbai`     | Test       |
+| `80002`    | Polygon Testnet Amoy     | `Amoy`       | Test       |
 | `50`       | XDC Network              | `xdc`        | Production |
 | `51`       | XDC Apothem Network      | `xdcapothem` | Test       |
 

--- a/src/commands/config/config.type.ts
+++ b/src/commands/config/config.type.ts
@@ -11,6 +11,6 @@ export interface CreateConfigCommand {
 export enum TestNetwork {
   Local = "local",
   Sepolia = "sepolia",
-  Mumbai = "mumbai (polygon)",
+  Amoy = "amoy (polygon)",
   Apothem = "apothem (xdc)",
 }

--- a/src/commands/config/create.ts
+++ b/src/commands/config/create.ts
@@ -60,7 +60,7 @@ export const handler = async (args: CreateConfigCommand): Promise<void> => {
       args.configTemplatePath = configTemplatePath;
     }
 
-    const networks = [TestNetwork.Local, TestNetwork.Sepolia, TestNetwork.Mumbai, TestNetwork.Apothem];
+    const networks = [TestNetwork.Local, TestNetwork.Sepolia, TestNetwork.Amoy, TestNetwork.Apothem];
     const { network } = await inquirer.prompt({
       type: "list",
       name: "network",
@@ -82,7 +82,7 @@ const convertNetworkToNetworkCmdName = (selectedNetwork: TestNetwork): NetworkCm
   const network = {
     [TestNetwork.Local]: NetworkCmdName.Local,
     [TestNetwork.Sepolia]: NetworkCmdName.Sepolia,
-    [TestNetwork.Mumbai]: NetworkCmdName.Maticmum,
+    [TestNetwork.Amoy]: NetworkCmdName.Amoy,
     [TestNetwork.Apothem]: NetworkCmdName.XDCApothem,
   };
   return network[selectedNetwork];

--- a/src/common/networks.ts
+++ b/src/common/networks.ts
@@ -18,7 +18,7 @@ export enum NetworkCmdName {
   Mainnet = "mainnet",
   Sepolia = "sepolia",
   Matic = "matic",
-  Maticmum = "maticmum",
+  Amoy = "amoy",
   XDC = "xdc",
   XDCApothem = "xdcapothem",
 }
@@ -65,13 +65,12 @@ export const supportedNetwork: {
     currency: "MATIC",
     gasStation: gasStation("https://gasstation.polygon.technology/v2"),
   },
-  [NetworkCmdName.Maticmum]: {
-    explorer: "https://mumbai.polygonscan.com",
-    provider: defaultInfuraProvider("maticmum"),
-    networkId: 80001,
-    networkName: NetworkCmdName.Maticmum,
+  [NetworkCmdName.Amoy]: {
+    explorer: "https://www.oklink.com/amoy",
+    provider: jsonRpcProvider("https://polygon-amoy.infura.io/v3/bb46da3f80e040e8ab73c0a9ff365d18"),
+    networkId: 80002,
+    networkName: NetworkCmdName.Amoy,
     currency: "MATIC",
-    gasStation: gasStation("https://gasstation-testnet.polygon.technology/v2"),
   },
   [NetworkCmdName.XDC]: {
     explorer: "https://xdcscan.io",

--- a/src/common/networks.ts
+++ b/src/common/networks.ts
@@ -71,6 +71,7 @@ export const supportedNetwork: {
     networkId: 80002,
     networkName: NetworkCmdName.Amoy,
     currency: "MATIC",
+    gasStation: gasStation("https://gasstation-testnet.polygon.technology/amoy"),
   },
   [NetworkCmdName.XDC]: {
     explorer: "https://xdcscan.io",


### PR DESCRIPTION
## Context
- https://polygon.technology/blog/introducing-the-amoy-testnet-for-polygon-pos
- https://www.alchemy.com/blog/polygon-mumbai-testnet-deprecation

## What this PR does
- replace Polygon Mumbai with Polygon Amoy 

### References
- https://docs.polygon.technology/pos/reference/rpc-endpoints/#mumbai-deprecating-soon
- https://polygon.technology/blog/introducing-the-amoy-testnet-for-polygon-pos (connect to Amoy)