### PR TITLE
Add CamDL and CamDL Testnet to the supported network

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ Upon installation, a configuration folder will be created at `~/.config/open-att
 
 ## Supported networks
 
-| Network ID | Name                     | Network      | Type       |
-| ---------- | ------------------------ | ------------ | ---------- |
-| `1`        | Ethereum Mainnet         | `mainnet`    | Production |
-| `11155111` | Ethereum Testnet Sepolia | `sepolia`    | Test       |
-| `137`      | Polygon Mainnet          | `polygon`    | Production |
-| `80002`    | Polygon Testnet Amoy     | `Amoy`       | Test       |
-| `50`       | XDC Network              | `xdc`        | Production |
-| `51`       | XDC Apothem Network      | `xdcapothem` | Test       |
-
+| Network ID | Name                     | Network         | Type       |
+| ---------- | ------------------------ | --------------- | ---------- |
+| `1`        | Ethereum Mainnet         | `mainnet`       | Production |
+| `11155111` | Ethereum Testnet Sepolia | `sepolia`       | Test       |
+| `137`      | Polygon Mainnet          | `polygon`       | Production |
+| `80002`    | Polygon Testnet Amoy     | `Amoy`          | Test       |
+| `50`       | XDC Network              | `xdc`           | Production |
+| `51`       | XDC Apothem Network      | `xdcapothem`    | Test       |
+| `95`       | CamDL Network            | `camdl`         | Production |
+| `395`      | CamDL Test Network       | `camdl-testnet` | Test       |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
         "yargs": "^17.0.1"
       },
       "bin": {
-        "oa": "dist/cjs/index.js",
-        "open-attestation": "dist/cjs/index.js"
+        "oa": "dist/cjs/src/index.js",
+        "open-attestation": "dist/cjs/src/index.js"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",

--- a/src/commands/config/config.type.ts
+++ b/src/commands/config/config.type.ts
@@ -13,4 +13,5 @@ export enum TestNetwork {
   Sepolia = "sepolia",
   Amoy = "amoy (polygon)",
   Apothem = "apothem (xdc)",
+  CamdlTestnet = "camdl (testnet)",
 }

--- a/src/commands/config/create.ts
+++ b/src/commands/config/create.ts
@@ -60,7 +60,7 @@ export const handler = async (args: CreateConfigCommand): Promise<void> => {
       args.configTemplatePath = configTemplatePath;
     }
 
-    const networks = [TestNetwork.Local, TestNetwork.Sepolia, TestNetwork.Amoy, TestNetwork.Apothem];
+    const networks = [TestNetwork.Local, TestNetwork.Sepolia, TestNetwork.Amoy, TestNetwork.Apothem, TestNetwork.CamdlTestnet];
     const { network } = await inquirer.prompt({
       type: "list",
       name: "network",
@@ -84,6 +84,7 @@ const convertNetworkToNetworkCmdName = (selectedNetwork: TestNetwork): NetworkCm
     [TestNetwork.Sepolia]: NetworkCmdName.Sepolia,
     [TestNetwork.Amoy]: NetworkCmdName.Amoy,
     [TestNetwork.Apothem]: NetworkCmdName.XDCApothem,
+    [TestNetwork.CamdlTestnet]: NetworkCmdName.CamdlTestnet,
   };
   return network[selectedNetwork];
 };

--- a/src/common/networks.ts
+++ b/src/common/networks.ts
@@ -2,7 +2,7 @@ import { providers } from "ethers";
 import type { GasStationFunction } from "./gas-station";
 import { gasStation } from "./gas-station";
 
-export type networkCurrency = "ETH" | "MATIC" | "XDC";
+export type networkCurrency = "ETH" | "MATIC" | "XDC" | "CADL";
 
 type SupportedNetwork = {
   explorer: string;
@@ -21,6 +21,8 @@ export enum NetworkCmdName {
   Amoy = "amoy",
   XDC = "xdc",
   XDCApothem = "xdcapothem",
+  Camdl = "camdl",
+  CamdlTestnet = "camdl-testnet",
 }
 
 const defaultInfuraProvider =
@@ -86,6 +88,20 @@ export const supportedNetwork: {
     networkId: 51,
     networkName: NetworkCmdName.XDCApothem,
     currency: "XDC",
+  },
+  [NetworkCmdName.Camdl]: {
+    explorer: "https://explorer.camdl.gov.kh",
+    provider: jsonRpcProvider("https://rpc1.camdl.gov.kh"),
+    networkId: 95,
+    networkName: NetworkCmdName.Camdl,
+    currency: "CADL",
+  },
+  [NetworkCmdName.CamdlTestnet]: {
+    explorer: "https://explorer.testnet.camdl.gov.kh",
+    provider: jsonRpcProvider("https://rpc1.testnet.camdl.gov.kh"),
+    networkId: 395,
+    networkName: NetworkCmdName.CamdlTestnet,
+    currency: "CADL",
   },
 };
 


### PR DESCRIPTION
## Summary

CamDL is blockchain network run by Ministry of Economy of Finance in Cambodia, with the initiative to provide the public a platform to experiment or develop any Web3 application to solve everyday problems or be part of the DeFi ecosystem.

## Changes

Added support to CamDL and CamDL testnet.

